### PR TITLE
Record cancellation reason

### DIFF
--- a/Bikorwa/src/views/ventes/index.php
+++ b/Bikorwa/src/views/ventes/index.php
@@ -141,6 +141,11 @@ if (isset($_POST['action']) && $_POST['action'] === 'cancel_sale') {
         $query = "UPDATE ventes SET statut_vente = 'annulee' WHERE id = ?";
         $stmt = $pdo->prepare($query);
         $stmt->execute([$vente_id]);
+
+        // Save the cancellation reason in the note field
+        $query = "UPDATE ventes SET note = ? WHERE id = ?";
+        $stmt = $pdo->prepare($query);
+        $stmt->execute([$raison, $vente_id]);
         
         // Update any debt records if they exist
         $query = "UPDATE dettes SET statut = 'annulee' WHERE vente_id = ?";


### PR DESCRIPTION
## Summary
- store the reason for cancellation in the sale note when cancelling

## Testing
- `php -l Bikorwa/src/views/ventes/index.php` *(fails: `php` not installed)*

------
https://chatgpt.com/codex/tasks/task_e_685c112f312483249e950e0a278c4f77