### PR TITLE
Update receptionist permissions

### DIFF
--- a/Bikorwa/src/api/clients/delete_client.php
+++ b/Bikorwa/src/api/clients/delete_client.php
@@ -32,6 +32,15 @@ if (!$auth->hasAccess('clients')) {
     exit;
 }
 
+// Only managers can delete clients
+if (!$auth->isManager()) {
+    echo json_encode([
+        'success' => false,
+        'message' => 'Seuls les gestionnaires peuvent supprimer un client.'
+    ]);
+    exit;
+}
+
 // Get current user ID for logging actions
 $current_user_id = $_SESSION['user_id'] ?? 0;
 

--- a/Bikorwa/src/api/clients/update_client.php
+++ b/Bikorwa/src/api/clients/update_client.php
@@ -32,6 +32,15 @@ if (!$auth->hasAccess('clients')) {
     exit;
 }
 
+// Only managers can modify clients
+if (!$auth->isManager()) {
+    echo json_encode([
+        'success' => false,
+        'message' => 'Seuls les gestionnaires peuvent modifier un client.'
+    ]);
+    exit;
+}
+
 // Get current user ID for logging actions
 $current_user_id = $_SESSION['user_id'] ?? 0;
 

--- a/Bikorwa/src/api/dettes/update_dette.php
+++ b/Bikorwa/src/api/dettes/update_dette.php
@@ -18,6 +18,13 @@ if (!$auth->isLoggedIn()) {
     exit;
 }
 
+// Only managers can modify debts
+if (!$auth->isManager()) {
+    http_response_code(403);
+    echo json_encode(["success" => false, "message" => "Seuls les gestionnaires peuvent modifier une dette"]);
+    exit;
+}
+
 // Get user ID for logging
 $user_id = $_SESSION['user_id'] ?? 0;
 

--- a/Bikorwa/src/views/clients/index.php
+++ b/Bikorwa/src/views/clients/index.php
@@ -28,6 +28,7 @@ if (!$auth->hasAccess('clients')) {
 
 // Get current user ID for logging actions
 $current_user_id = $_SESSION['user_id'] ?? 0;
+$userRole = $_SESSION['user_role'] ?? '';
 
 // Set default values and get search parameters
 $search = $_GET['search'] ?? '';
@@ -364,12 +365,14 @@ $use_custom_footer = true;
                                         <button type="button" class="btn btn-sm btn-info btn-action btn-view-client" data-id="<?php echo $client['id']; ?>" title="Voir les détails">
                                             <i class="fas fa-eye"></i>
                                         </button>
+                                        <?php if ($userRole === 'gestionnaire'): ?>
                                         <button type="button" class="btn btn-sm btn-primary btn-action btn-edit-client" data-id="<?php echo $client['id']; ?>" title="Modifier">
                                             <i class="fas fa-edit"></i>
                                         </button>
                                         <button type="button" class="btn btn-sm btn-danger btn-action btn-delete-client" data-id="<?php echo $client['id']; ?>" data-name="<?php echo htmlspecialchars($client['nom']); ?>" title="Supprimer">
                                             <i class="fas fa-trash"></i>
                                         </button>
+                                        <?php endif; ?>
                                     </td>
                                 </tr>
                             <?php endforeach; ?>

--- a/Bikorwa/src/views/dettes/fixed_script.js
+++ b/Bikorwa/src/views/dettes/fixed_script.js
@@ -47,9 +47,13 @@ document.addEventListener('DOMContentLoaded', function() {
         });
     });
     
-    // Edit debt
+    // Edit debt - only managers
     document.querySelectorAll('.editBtn').forEach(btn => {
         btn.addEventListener('click', function() {
+            if (!isManager) {
+                showToast('Erreur', 'Seuls les gestionnaires peuvent modifier des dettes', 'error');
+                return;
+            }
             const detteId = this.getAttribute('data-id');
             loadDetteForEdit(detteId);
         });

--- a/Bikorwa/src/views/dettes/index.php
+++ b/Bikorwa/src/views/dettes/index.php
@@ -467,9 +467,11 @@ require_once __DIR__ . '/../layouts/header.php';
                                                     <i class="fas fa-money-bill"></i>
                                                 </button>
                                                 
+                                                <?php if ($userRole === 'gestionnaire'): ?>
                                                 <button class="btn btn-sm btn-primary btn-action editBtn" data-id="<?php echo $dette['id']; ?>" title="Modifier">
                                                     <i class="fas fa-edit"></i>
                                                 </button>
+                                                <?php endif; ?>
                                                 
                                                 <?php if ($userRole === 'gestionnaire'): ?>
                                                 <button class="btn btn-sm btn-danger btn-action deleteBtn" data-id="<?php echo $dette['id']; ?>" title="Annuler">

--- a/Bikorwa/src/views/layouts/header.php
+++ b/Bikorwa/src/views/layouts/header.php
@@ -260,8 +260,7 @@
                 <span>Tableau de Bord</span>
             </a>
             
-            <?php if ($user_role === 'gestionnaire'): ?>
-            <!-- Gestion des Ventes (gestionnaire only) -->
+            <!-- Gestion des Ventes -->
             <div class="sidebar-dropdown">
                 <a href="#" class="sidebar-item <?php echo $active_page == 'ventes' ? 'active' : ''; ?>" data-bs-toggle="collapse" data-bs-target="#venteSubMenu" aria-expanded="false">
                     <i class="fas fa-shopping-cart"></i>
@@ -274,14 +273,15 @@
                             <i class="fas fa-plus-circle"></i>
                             <span>Nouvelle Vente</span>
                         </a>
+                        <?php if ($user_role === 'gestionnaire'): ?>
                         <a href="<?php echo BASE_URL; ?>/src/views/ventes/index.php" class="sidebar-subitem">
                             <i class="fas fa-history"></i>
                             <span>Historique des Ventes</span>
                         </a>
+                        <?php endif; ?>
                     </div>
                 </div>
             </div>
-            <?php endif; ?>
             
             <!-- Gestion des Stocks -->
             <div class="sidebar-dropdown">
@@ -296,27 +296,27 @@
                             <i class="fas fa-clipboard-list"></i>
                             <span>Inventaire</span>
                         </a>
-                        <?php if ($user_role === 'gestionnaire'): ?>
                         <a href="<?php echo BASE_URL; ?>/src/views/stock/ajustement.php" class="sidebar-subitem">
                             <i class="fas fa-sliders-h"></i>
                             <span>Ajustement de Stock</span>
                         </a>
-                        <?php endif; ?>
+                        <?php if ($user_role === 'gestionnaire'): ?>
                         <a href="<?php echo BASE_URL; ?>/src/views/stock/historique_approvisionnement.php" class="sidebar-subitem">
                             <i class="fas fa-history"></i>
                             <span>Historique d'approvisionnement</span>
                         </a>
+                        <?php endif; ?>
                     </div>
                 </div>
             </div>
             
-            <?php if ($user_role === 'gestionnaire'): ?>
-            <!-- Gestion des Dettes (gestionnaire only) -->
+            <!-- Gestion des Dettes -->
             <a href="<?php echo BASE_URL; ?>/src/views/dettes/index.php" class="sidebar-item <?php echo $active_page == 'dettes' ? 'active' : ''; ?>">
                 <i class="fas fa-money-check-alt"></i>
                 <span>Gestion des Dettes</span>
             </a>
-            
+
+            <?php if ($user_role === 'gestionnaire'): ?>
             <!-- Gestion des Employés (gestionnaire only) -->
             <div class="sidebar-dropdown">
                 <a href="#" class="sidebar-item <?php echo $active_page == 'employes' ? 'active' : ''; ?>" data-bs-toggle="collapse" data-bs-target="#employesSubMenu" aria-expanded="false">
@@ -341,8 +341,10 @@
                     </div>
                 </div>
             </div>
-            
-            <!-- Gestion des Dépenses (gestionnaire only) -->
+
+            <?php endif; ?>
+
+            <!-- Gestion des Dépenses -->
             <div class="sidebar-dropdown">
                 <a href="#" class="sidebar-item <?php echo in_array($active_page, ['depenses-jour', 'depenses-historique']) ? 'active' : ''; ?>" data-bs-toggle="collapse" data-bs-target="#depensesSubMenu" aria-expanded="false">
                     <i class="fas fa-money-bill-wave"></i>
@@ -354,13 +356,14 @@
                         <i class="fas fa-money-bill-wave"></i>
                         <span>Dépenses du Jour</span>
                     </a>
+                    <?php if ($user_role === 'gestionnaire'): ?>
                     <a href="../depenses/historique.php" class="sidebar-item <?php echo $active_page == 'depenses-historique' ? 'active' : ''; ?>">
                         <i class="fas fa-history"></i>
                         <span>Historique des Dépenses</span>
                     </a>
+                    <?php endif; ?>
                 </div>
             </div>
-            <?php endif; ?>
             
             <!-- Gestion des Clients -->
             <a href="<?php echo BASE_URL; ?>/src/views/clients/index.php" class="sidebar-item <?php echo $active_page == 'clients' ? 'active' : ''; ?>">


### PR DESCRIPTION
## Summary
- show only 'historique' actions for manager in navigation
- allow stock adjustments for both roles but restrict history to manager
- restrict debt editing and client modifications to manager
- hide edit/delete buttons for receptionist

## Testing
- `php -l` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_685c25878adc8324aea9355bfd55c394