### PR TITLE
Allow receptionists to manage stock (no delete)

### DIFF
--- a/Bikorwa/src/views/stock/inventaire_modals.php
+++ b/Bikorwa/src/views/stock/inventaire_modals.php
@@ -307,7 +307,7 @@
             </div>
             <div class="modal-footer">
                 <button type="button" class="btn btn-secondary" data-bs-dismiss="modal">Fermer</button>
-                <?php if ($isGestionnaire): ?>
+                <?php if ($hasStockAccess): ?>
                 <button type="button" class="btn btn-primary" id="viewToEditBtn">Modifier</button>
                 <?php endif; ?>
             </div>


### PR DESCRIPTION
## Summary
- permit both gestionnaire and receptionniste roles to add and edit stock
- show inventory actions for receptionnistes except delete
- allow edit option in details modal for receptionnistes
- clarified comments about stock privileges

## Testing
- `php -l Bikorwa/src/views/stock/inventaire.php`
- `php -l Bikorwa/src/views/stock/inventaire_modals.php`


------
https://chatgpt.com/codex/tasks/task_e_685c3489d5c483249748da1c14db38fc