### PR TITLE
Add application settings page

### DIFF
--- a/Bikorwa/sql/create_database.sql
+++ b/Bikorwa/sql/create_database.sql
@@ -220,3 +220,15 @@ INSERT INTO categories (nom, description) VALUES
 ('Vins', 'Vins et champagnes'),
 ('Autres', 'Autres produits');
 
+
+-- Table des parametres de l'application
+CREATE TABLE IF NOT EXISTS settings (
+    id INT AUTO_INCREMENT PRIMARY KEY,
+    name VARCHAR(100) UNIQUE NOT NULL,
+    value TEXT NOT NULL
+);
+
+-- Valeurs par defaut pour les parametres
+INSERT INTO settings (name, value) VALUES
+('theme','light'),
+('shop_name','BIKORWA SHOP');

--- a/Bikorwa/src/api/settings/update.php
+++ b/Bikorwa/src/api/settings/update.php
@@ -1,0 +1,28 @@
+<?php
+header('Content-Type: application/json');
+require_once './../../config/config.php';
+require_once './../../config/database.php';
+require_once './../../utils/Auth.php';
+require_once './../../utils/Settings.php';
+
+$database = new Database();
+$conn = $database->getConnection();
+$auth = new Auth($conn);
+
+if (!$auth->isLoggedIn() || !$auth->isManager()) {
+    echo json_encode(['success' => false, 'message' => "Accès refusé"]);
+    exit;
+}
+
+$settings = new Settings($conn);
+$theme = $_POST['theme'] ?? 'light';
+$shopName = trim($_POST['shop_name'] ?? '');
+$itemsPerPage = isset($_POST['items_per_page']) ? (int)$_POST['items_per_page'] : 10;
+
+$settings->set('theme', $theme === 'dark' ? 'dark' : 'light');
+if ($shopName !== '') {
+    $settings->set('shop_name', $shopName);
+}
+$settings->set('items_per_page', $itemsPerPage);
+
+echo json_encode(['success' => true, 'message' => 'Paramètres enregistrés']);

--- a/Bikorwa/src/utils/Settings.php
+++ b/Bikorwa/src/utils/Settings.php
@@ -1,0 +1,24 @@
+<?php
+class Settings {
+    private $conn;
+    public function __construct($db) {
+        $this->conn = $db;
+    }
+
+    public function get($name, $default = null) {
+        $stmt = $this->conn->prepare('SELECT value FROM settings WHERE name = ?');
+        $stmt->execute([$name]);
+        $value = $stmt->fetchColumn();
+        return $value !== false ? $value : $default;
+    }
+
+    public function set($name, $value) {
+        $stmt = $this->conn->prepare('INSERT INTO settings (name, value) VALUES (?, ?) ON DUPLICATE KEY UPDATE value = VALUES(value)');
+        return $stmt->execute([$name, $value]);
+    }
+
+    public function getAll() {
+        $stmt = $this->conn->query('SELECT name, value FROM settings');
+        return $stmt->fetchAll(PDO::FETCH_KEY_PAIR);
+    }
+}

--- a/Bikorwa/src/views/clients/index.php
+++ b/Bikorwa/src/views/clients/index.php
@@ -6,10 +6,12 @@ $active_page = "clients";
 require_once './../../../src/config/config.php';
 require_once './../../../src/config/database.php';
 require_once './../../../src/utils/Auth.php';
+require_once './../../../src/utils/Settings.php';
 
 // Initialize database connection
 $database = new Database();
 $conn = $database->getConnection();
+$settingsObj = new Settings($conn);
 
 // Initialize authentication
 $auth = new Auth($conn);
@@ -33,7 +35,7 @@ $userRole = $_SESSION['user_role'] ?? '';
 // Set default values and get search parameters
 $search = $_GET['search'] ?? '';
 $current_page = isset($_GET['page']) ? (int)$_GET['page'] : 1;
-$items_per_page = 10;
+$items_per_page = (int)$settingsObj->get('items_per_page', 10);
 $offset = ($current_page - 1) * $items_per_page;
 
 // Build the base query

--- a/Bikorwa/src/views/employes/liste.php
+++ b/Bikorwa/src/views/employes/liste.php
@@ -8,10 +8,12 @@ require_once './../../../src/config/database.php';
 require_once './../../../src/utils/Auth.php';
 require_once './../../../src/models/User.php';
 require_once './../../../src/controllers/AuthController.php';
+require_once './../../../src/utils/Settings.php';
 
 // Initialize database connection
 $database = new Database();
 $conn = $database->getConnection();
+$settingsObj = new Settings($conn);
 
 // Initialize auth
 $auth = new Auth($conn);
@@ -27,7 +29,7 @@ if (!$auth->isLoggedIn()) {
 $search = $_GET['search'] ?? '';
 $statut = $_GET['statut'] ?? '';
 $current_page = isset($_GET['page']) ? (int)$_GET['page'] : 1;
-$items_per_page = 10;
+$items_per_page = (int)$settingsObj->get('items_per_page', 10);
 $offset = ($current_page - 1) * $items_per_page;
 
 // Build the base query

--- a/Bikorwa/src/views/layouts/header.php
+++ b/Bikorwa/src/views/layouts/header.php
@@ -1,9 +1,20 @@
+<?php
+require_once __DIR__ . '/../../config/database.php';
+require_once __DIR__ . '/../utils/Settings.php';
+if (!isset($pdo)) {
+    $database = new Database();
+    $pdo = $database->getConnection();
+}
+$settingsObj = new Settings($pdo);
+$theme_mode = $settingsObj->get('theme', 'light');
+$app_name_setting = $settingsObj->get('shop_name', APP_NAME);
+?>
 <!DOCTYPE html>
 <html lang="fr">
 <head>
     <meta charset="UTF-8">
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
-    <title>BIKORWA SHOP - <?php echo $page_title ?? 'Gestion de Bar'; ?></title>
+    <title><?= htmlspecialchars($app_name_setting) ?> - <?php echo $page_title ?? 'Gestion de Bar'; ?></title>
     
     <!-- Bootstrap CSS -->
     <link href="https://cdn.jsdelivr.net/npm/bootstrap@5.3.0/dist/css/bootstrap.min.css" rel="stylesheet">
@@ -35,6 +46,24 @@
         body {
             background-color: var(--light);
             font-family: 'Nunito', -apple-system, BlinkMacSystemFont, 'Segoe UI', Roboto, 'Helvetica Neue', Arial, sans-serif;
+        }
+        body.dark-theme {
+            background-color: #343a40;
+            color: #f8f9fa;
+        }
+        body.dark-theme .sidebar,
+        body.dark-theme .topbar,
+        body.dark-theme .sidebar-brand {
+            background-color: #212529;
+            color: #f8f9fa;
+        }
+        body.dark-theme .sidebar-item,
+        body.dark-theme .sidebar-subitem {
+            color: #adb5bd;
+        }
+        body.dark-theme .sidebar-item.active {
+            background-color: #343a40;
+            color: #fff;
         }
         
         /* Sidebar Styles */
@@ -234,14 +263,14 @@
                 margin-left: 0;
             }
         }
-    </style>
+</style>
 </head>
-<body>
+<body class="<?= $theme_mode === 'dark' ? 'dark-theme' : '' ?>">
     <!-- Sidebar -->
     <div class="sidebar">
         <div class="sidebar-brand">
             <i class="fas fa-store me-2"></i>
-            <span><?php echo htmlspecialchars(APP_NAME); ?></span>
+            <span><?= htmlspecialchars($app_name_setting) ?></span>
         </div>
         
         <div class="sidebar-menu">
@@ -398,7 +427,7 @@
             </div>
             
             <!-- Paramètres (gestionnaire only) -->
-            <a href="#" class="sidebar-item <?php echo $active_page == 'parametres' ? 'active' : ''; ?>">
+            <a href="<?php echo BASE_URL; ?>/src/views/parametres/application.php" class="sidebar-item <?php echo $active_page == 'parametres' ? 'active' : ''; ?>">
                 <i class="fas fa-cog"></i>
                 <span>Paramètres</span>
             </a>

--- a/Bikorwa/src/views/parametres/application.php
+++ b/Bikorwa/src/views/parametres/application.php
@@ -1,0 +1,60 @@
+<?php
+// Page de configuration de l'application
+$page_title = "Paramètres de l'application";
+$active_page = "parametres";
+
+require_once './../../../src/config/config.php';
+require_once './../../../src/config/database.php';
+require_once './../../../src/utils/Auth.php';
+require_once './../../../src/utils/Settings.php';
+
+$database = new Database();
+$pdo = $database->getConnection();
+$auth = new Auth($pdo);
+
+if (!$auth->isLoggedIn() || !$auth->isManager()) {
+    header('Location: ' . BASE_URL . '/src/views/dashboard/index.php');
+    exit;
+}
+
+$settings = new Settings($pdo);
+$current_theme = $settings->get('theme', 'light');
+$shop_name = $settings->get('shop_name', APP_NAME);
+$items_per_page = $settings->get('items_per_page', 10);
+
+require_once __DIR__ . '/../layouts/header.php';
+?>
+<div class="container">
+    <h2 class="mb-4">Paramètres Généraux</h2>
+    <form id="settingsForm">
+        <div class="mb-3">
+            <label class="form-label" for="shop_name">Nom du shop / application</label>
+            <input type="text" class="form-control" id="shop_name" name="shop_name" value="<?= htmlspecialchars($shop_name) ?>">
+        </div>
+        <div class="mb-3">
+            <label class="form-label" for="theme">Mode de thème</label>
+            <select class="form-select" id="theme" name="theme">
+                <option value="light" <?= $current_theme==='light'?'selected':'' ?>>Clair</option>
+                <option value="dark" <?= $current_theme==='dark'?'selected':'' ?>>Sombre</option>
+            </select>
+        </div>
+        <div class="mb-3">
+            <label class="form-label" for="items_per_page">Éléments par page</label>
+            <input type="number" min="1" class="form-control" id="items_per_page" name="items_per_page" value="<?= intval($items_per_page) ?>">
+        </div>
+        <button type="submit" class="btn btn-primary">Enregistrer</button>
+    </form>
+    <div id="settingsAlert" class="mt-3"></div>
+</div>
+<script>
+const form = document.getElementById('settingsForm');
+form.addEventListener('submit', async (e) => {
+    e.preventDefault();
+    const data = new FormData(form);
+    const res = await fetch('../../api/settings/update.php', { method: 'POST', body: data });
+    const json = await res.json();
+    const alert = `<div class="alert alert-${json.success?'success':'danger'}">${json.message}</div>`;
+    document.getElementById('settingsAlert').innerHTML = alert;
+});
+</script>
+<?php require_once __DIR__ . '/../layouts/footer.php'; ?>

--- a/Bikorwa/src/views/ventes/facture.php
+++ b/Bikorwa/src/views/ventes/facture.php
@@ -7,6 +7,7 @@ if (session_status() === PHP_SESSION_NONE) {
 // Load configuration and database
 $config = require_once('../../config/config.php');
 require_once('../../config/database.php');
+require_once('../../utils/Settings.php');
 
 // Check if user is logged in
 if (!isset($_SESSION['logged_in']) || $_SESSION['logged_in'] !== true) {
@@ -17,6 +18,8 @@ if (!isset($_SESSION['logged_in']) || $_SESSION['logged_in'] !== true) {
 // Initialize database connection
 $db = new Database();
 $pdo = $db->getConnection();
+$settings = new Settings($pdo);
+$config['shop_info']['name'] = $settings->get('shop_name', $config['shop_info']['name']);
 
 $vente_id = isset($_GET['id']) ? intval($_GET['id']) : 0;
 if ($vente_id <= 0) {


### PR DESCRIPTION
## Summary
- create a `settings` table and default data
- add `Settings` utility class
- add API endpoint for updating settings
- display shop name and theme from database
- new settings page to manage theme, shop name and pagination
- apply pagination setting in clients and employees pages
- update invoice and navigation links

## Testing
- `php` not available, unable to run syntax checks

------
https://chatgpt.com/codex/tasks/task_e_685d2c0c92f083248d308b9ed47fc190