### PR TITLE
Fix incorrect include path in header

### DIFF
--- a/Bikorwa/src/views/layouts/header.php
+++ b/Bikorwa/src/views/layouts/header.php
@@ -1,6 +1,6 @@
 <?php
 require_once __DIR__ . '/../../config/database.php';
-require_once __DIR__ . '/../utils/Settings.php';
+require_once __DIR__ . '/../../utils/Settings.php';
 if (!isset($pdo)) {
     $database = new Database();
     $pdo = $database->getConnection();


### PR DESCRIPTION
## Summary
- fix path to `Settings.php` in header include

## Testing
- `php -v` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_685d2ea6782083248b06ce95d48c4966