### PR TITLE
Restrict stock removal to gestionnaire only

### DIFF
--- a/Bikorwa/src/views/stock/inventaire.php
+++ b/Bikorwa/src/views/stock/inventaire.php
@@ -334,6 +334,11 @@ if ($_SERVER['REQUEST_METHOD'] === 'POST') {
             if ($type_mouvement !== 'entree' && $type_mouvement !== 'sortie') {
                 throw new Exception("Type de mouvement invalide.");
             }
+
+            // Receptionnistes are not allowed to perform stock removals
+            if (!$isGestionnaire && $type_mouvement === 'sortie') {
+                throw new Exception("Seul le gestionnaire peut effectuer une sortie de stock.");
+            }
             
             // Get current product info
             $stmt = $pdo->prepare("

--- a/Bikorwa/src/views/stock/inventaire_modals.php
+++ b/Bikorwa/src/views/stock/inventaire_modals.php
@@ -352,7 +352,7 @@
                                 </label>
                             </div>
                             <div class="form-check">
-                                <input class="form-check-input" type="radio" name="type_mouvement" id="type_sortie" value="sortie">
+                                <input class="form-check-input" type="radio" name="type_mouvement" id="type_sortie" value="sortie" <?= $isGestionnaire ? '' : 'disabled' ?> >
                                 <label class="form-check-label" for="type_sortie">
                                     <i class="fas fa-arrow-alt-circle-up text-danger me-1"></i> Sortie
                                 </label>


### PR DESCRIPTION
## Summary
- prevent receptionnistes from choosing `Sortie` when adjusting stock
- server-side check ensures only gestionnaire can make stock removals

## Testing
- `php -l Bikorwa/src/views/stock/inventaire_modals.php`
- `php -l Bikorwa/src/views/stock/inventaire.php`


------
https://chatgpt.com/codex/tasks/task_e_685d41cf9b748324beb16cb820b77ac7