### PR TITLE
Add modal navigation shortcuts

### DIFF
--- a/Bikorwa/src/ajax/adjust_stock.php
+++ b/Bikorwa/src/ajax/adjust_stock.php
@@ -1,0 +1,127 @@
+<?php
+// AJAX endpoint to adjust stock without reloading page
+if (session_status() === PHP_SESSION_NONE) {
+    session_start();
+}
+
+require_once './../../config/database.php';
+require_once './../../config/config.php';
+
+header('Content-Type: application/json');
+
+if (!isset($_SESSION['logged_in']) || $_SESSION['logged_in'] !== true) {
+    echo json_encode(['success' => false, 'message' => 'Vous devez être connecté pour effectuer cette action']);
+    exit;
+}
+
+$db = new Database();
+$pdo = $db->getConnection();
+
+$isGestionnaire = isset($_SESSION['user_role']) && $_SESSION['user_role'] === 'gestionnaire';
+$isReceptionniste = isset($_SESSION['user_role']) && $_SESSION['user_role'] === 'receptionniste';
+$hasStockAccess = $isGestionnaire || $isReceptionniste;
+
+if (!$hasStockAccess) {
+    echo json_encode(['success' => false, 'message' => "Vous n'avez pas les droits pour ajuster le stock."]);
+    exit;
+}
+
+$produit_id = intval($_POST['produit_id'] ?? 0);
+$type_mouvement = $_POST['type_mouvement'] ?? '';
+$quantite = floatval(str_replace(',', '.', $_POST['quantite'] ?? '0'));
+$note = trim($_POST['note'] ?? '');
+
+if ($quantite <= 0) {
+    echo json_encode(['success' => false, 'message' => 'La quantité doit être supérieure à zéro.']);
+    exit;
+}
+
+if ($type_mouvement !== 'entree' && $type_mouvement !== 'sortie') {
+    echo json_encode(['success' => false, 'message' => 'Type de mouvement invalide.']);
+    exit;
+}
+
+if (!$isGestionnaire && $type_mouvement === 'sortie') {
+    echo json_encode(['success' => false, 'message' => 'Seul le gestionnaire peut effectuer une sortie de stock.']);
+    exit;
+}
+
+try {
+    $pdo->beginTransaction();
+
+    $stmt = $pdo->prepare("SELECT p.nom, p.code, p.unite_mesure, s.quantite, pp.prix_achat
+                            FROM produits p
+                            LEFT JOIN stock s ON p.id = s.produit_id
+                            LEFT JOIN (
+                                SELECT produit_id, prix_achat
+                                FROM prix_produits
+                                WHERE date_fin IS NULL
+                                GROUP BY produit_id
+                            ) pp ON p.id = pp.produit_id
+                            WHERE p.id = :id");
+    $stmt->execute(['id' => $produit_id]);
+    $produit = $stmt->fetch(PDO::FETCH_ASSOC);
+
+    if (!$produit) {
+        throw new Exception('Produit introuvable.');
+    }
+
+    if ($type_mouvement === 'sortie' && $produit['quantite'] < $quantite) {
+        throw new Exception('Stock insuffisant. Quantité actuelle: ' . $produit['quantite']);
+    }
+
+    $new_quantity = ($type_mouvement === 'entree') ? $produit['quantite'] + $quantite : $produit['quantite'] - $quantite;
+
+    $stmt = $pdo->prepare("UPDATE stock SET quantite = :q, date_mise_a_jour = NOW() WHERE produit_id = :id");
+    $stmt->execute(['q' => $new_quantity, 'id' => $produit_id]);
+
+    $reference = ($type_mouvement === 'entree' ? 'AJOUT-' : 'RETRAIT-') . date('YmdHis');
+
+    $stmt = $pdo->prepare("INSERT INTO mouvements_stock (produit_id, type_mouvement, quantite, prix_unitaire, valeur_totale, utilisateur_id, note, reference, quantity_remaining)
+                           VALUES (:produit_id, :type_mouvement, :quantite, :prix_unitaire, :valeur_totale, :utilisateur_id, :note, :reference, :quantity_remaining)");
+    $stmt->execute([
+        'produit_id' => $produit_id,
+        'type_mouvement' => $type_mouvement,
+        'quantite' => $quantite,
+        'prix_unitaire' => $produit['prix_achat'],
+        'valeur_totale' => $produit['prix_achat'] * $quantite,
+        'utilisateur_id' => $_SESSION['user_id'],
+        'note' => $note,
+        'reference' => $reference,
+        'quantity_remaining' => $type_mouvement === 'entree' ? $quantite : null
+    ]);
+
+    $stmt = $pdo->prepare("INSERT INTO journal_activites (utilisateur_id, action, entite, entite_id, details)
+                           VALUES (:utilisateur_id, 'adjust', 'stock', :entite_id, :details)");
+    $stmt->execute([
+        'utilisateur_id' => $_SESSION['user_id'],
+        'entite_id' => $produit_id,
+        'details' => 'Ajustement de stock: ' . $produit['nom'] . ' - ' . ($type_mouvement === 'entree' ? 'Ajout' : 'Retrait') . ' de ' . $quantite . ' ' . $produit['unite_mesure']
+    ]);
+
+    $pdo->commit();
+
+    $valeur_stock = $new_quantity * $produit['prix_achat'];
+    if ($new_quantity <= 0) {
+        $status_badge = '<span class="badge bg-danger">Rupture</span>';
+    } elseif ($new_quantity <= 10) {
+        $status_badge = '<span class="badge bg-warning text-dark">Stock bas</span>';
+    } else {
+        $status_badge = '<span class="badge bg-success">En stock</span>';
+    }
+
+    echo json_encode([
+        'success' => true,
+        'new_quantity' => $new_quantity,
+        'new_quantity_formatted' => number_format($new_quantity, 2, ',', ' '),
+        'new_valeur' => $valeur_stock,
+        'new_valeur_formatted' => number_format($valeur_stock, 0, ',', ' '),
+        'unite' => $produit['unite_mesure'],
+        'status_badge' => $status_badge
+    ]);
+} catch (Exception $e) {
+    if ($pdo->inTransaction()) {
+        $pdo->rollBack();
+    }
+    echo json_encode(['success' => false, 'message' => $e->getMessage()]);
+}

--- a/Bikorwa/src/views/stock/inventaire.php
+++ b/Bikorwa/src/views/stock/inventaire.php
@@ -774,12 +774,13 @@ include('../layouts/header.php');
                                 </button>
                                 
                                 <?php if ($hasStockAccess): ?>
-                                <button type="button" class="btn btn-sm btn-outline-secondary me-1"
+                                <button type="button" class="btn btn-sm btn-outline-secondary me-1 adjust-stock-btn"
                                         data-bs-toggle="modal" data-bs-target="#adjustStockModal"
                                         data-id="<?= $product['id'] ?>"
                                         data-nom="<?= htmlspecialchars($product['nom']) ?>"
                                         data-code="<?= htmlspecialchars($product['code']) ?>"
                                         data-unite="<?= htmlspecialchars($product['unite_mesure']) ?>"
+                                        data-prix-achat="<?= $product['prix_achat'] ?>"
                                         data-quantite="<?= number_format($product['quantite_stock'], 2, ',', ' ') ?>">
                                     <i class="fas fa-dolly-flatbed"></i>
                                 </button>
@@ -841,7 +842,7 @@ include('../layouts/header.php');
                             </tr>
                         <?php else: ?>
                             <?php foreach ($inventory as $product): ?>
-                                <tr>
+                                <tr id="product-row-<?= $product['id'] ?>">
                                     <td><code><?= htmlspecialchars($product['code']) ?></code></td>
                                     <td>
                                         <?= htmlspecialchars($product['nom']) ?>
@@ -851,7 +852,7 @@ include('../layouts/header.php');
                                     </td>
                                     <td><?= htmlspecialchars($product['categorie_nom'] ?? 'Non catégorisé') ?></td>
                                     <td><?= htmlspecialchars($product['unite_mesure']) ?></td>
-                                    <td class="text-end">
+                                    <td class="text-end" id="qty-<?= $product['id'] ?>">
                                         <?= number_format($product['quantite_stock'], 2, ',', ' ') ?>
                                     </td>
                                     <td class="text-end">
@@ -860,10 +861,10 @@ include('../layouts/header.php');
                                     <td class="text-end">
                                         <?= number_format($product['prix_vente'], 0, ',', ' ') ?> F
                                     </td>
-                                    <td class="text-end">
+                                    <td class="text-end" id="valeur-<?= $product['id'] ?>">
                                         <?= number_format($product['valeur_stock'], 0, ',', ' ') ?> F
                                     </td>
-                                    <td class="text-center">
+                                    <td class="text-center" id="status-<?= $product['id'] ?>">
                                         <?php if ($product['quantite_stock'] <= 0): ?>
                                             <span class="badge bg-danger">Rupture</span>
                                         <?php elseif ($product['quantite_stock'] <= 10): ?>
@@ -897,11 +898,12 @@ include('../layouts/header.php');
                                                 </li>
                                                 <?php if ($hasStockAccess): ?>
                                                 <li>
-                                                    <a class="dropdown-item" href="#" data-bs-toggle="modal" data-bs-target="#adjustStockModal"
+                                                    <a class="dropdown-item adjust-stock-btn" href="#" data-bs-toggle="modal" data-bs-target="#adjustStockModal"
                                                        data-id="<?= $product['id'] ?>"
                                                        data-nom="<?= htmlspecialchars($product['nom']) ?>"
                                                        data-code="<?= htmlspecialchars($product['code']) ?>"
                                                        data-unite="<?= htmlspecialchars($product['unite_mesure']) ?>"
+                                                       data-prix-achat="<?= $product['prix_achat'] ?>"
                                                        data-quantite="<?= number_format($product['quantite_stock'], 2, ',', ' ') ?>">
                                                         <i class="fas fa-dolly-flatbed me-2"></i> Ajuster stock
                                                     </a>


### PR DESCRIPTION
## Summary
- move prev/next icons to the footer of the stock adjustment modal
- support left/right arrow keys to switch items while modal stays open

## Testing
- `php -l Bikorwa/src/ajax/adjust_stock.php`
- `php -l Bikorwa/src/views/stock/inventaire_modals.php`
- `php -l Bikorwa/src/views/stock/inventaire.php`


------
https://chatgpt.com/codex/tasks/task_e_685d46f35e588324b2c90eb2f3fbfdd8