### PR TITLE
Fix sortie labeling for activity reports

### DIFF
--- a/Bikorwa/src/views/rapports/all_activities.php
+++ b/Bikorwa/src/views/rapports/all_activities.php
@@ -142,7 +142,8 @@ require_once __DIR__.'/../layouts/header.php';
                                 <?php
                                 if ($act['type_activite'] === 'sortie') {
                                     $detail = 'Vente';
-                                    if (isset($act['reference']) && strpos($act['reference'], 'ADJ-OUT') === 0) {
+                                    $ref = $act['reference'] ?? '';
+                                    if (stripos($ref, 'ADJ-OUT') === 0 || stripos($ref, 'RETRAIT') === 0) {
                                         $detail = 'Ajustement';
                                     }
                                     echo 'Sortie (' . $detail . ')';


### PR DESCRIPTION
## Summary
- correct detection of stock adjustments in `all_activities.php`

## Testing
- `php -l Bikorwa/src/views/rapports/all_activities.php` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_685d4fa6482483248efb95ebd6791c6d