### PR TITLE
Fix adjust_stock include paths

### DIFF
--- a/Bikorwa/src/ajax/adjust_stock.php
+++ b/Bikorwa/src/ajax/adjust_stock.php
@@ -4,8 +4,8 @@ if (session_status() === PHP_SESSION_NONE) {
     session_start();
 }
 
-require_once './../../config/database.php';
-require_once './../../config/config.php';
+require_once __DIR__ . '/../config/database.php';
+require_once __DIR__ . '/../config/config.php';
 
 header('Content-Type: application/json');
 


### PR DESCRIPTION
## Summary
- fix relative paths in `adjust_stock.php`

## Testing
- `php -r '$_POST=["produit_id"=>1,"type_mouvement"=>"entree","quantite"=>"1","note"=>"test"]; include "Bikorwa/src/ajax/adjust_stock.php";'`

------
https://chatgpt.com/codex/tasks/task_e_685d58b0ab1883248ebac0fe49eebb8f