### PR TITLE
Fix Adjust Stock next/prev buttons

### DIFF
--- a/Bikorwa/src/views/stock/inventaire_modals.php
+++ b/Bikorwa/src/views/stock/inventaire_modals.php
@@ -199,15 +199,9 @@
                         </div>
                     </div>
                 </div>
-                <div class="modal-footer d-flex justify-content-between">
-                    <div>
-                        <button type="button" class="btn btn-sm btn-outline-secondary me-2" id="adjustPrev" title="Précédent"><i class="fas fa-chevron-left"></i></button>
-                        <button type="button" class="btn btn-sm btn-outline-secondary" id="adjustNext" title="Suivant"><i class="fas fa-chevron-right"></i></button>
-                    </div>
-                    <div>
-                        <button type="button" class="btn btn-secondary" data-bs-dismiss="modal">Annuler</button>
-                        <button type="submit" class="btn btn-primary">Enregistrer</button>
-                    </div>
+                <div class="modal-footer">
+                    <button type="button" class="btn btn-secondary" data-bs-dismiss="modal">Annuler</button>
+                    <button type="submit" class="btn btn-primary">Enregistrer</button>
                 </div>
             </form>
         </div>


### PR DESCRIPTION
## Summary
- remove duplicate navigation buttons from Edit Product modal
- keep unique ids for next/previous in Adjust Stock modal

## Testing
- `php -l Bikorwa/src/views/stock/inventaire_modals.php`

------
https://chatgpt.com/codex/tasks/task_e_685d6bf9a2bc8324b35a2800d677a9d0