### PR TITLE
Implement DB-based session handler

### DIFF
--- a/Bikorwa/includes/auth_check.php
+++ b/Bikorwa/includes/auth_check.php
@@ -4,10 +4,10 @@
  * This file should be included at the top of all protected pages
  */
 
-// Start session if not already started
-if (session_status() === PHP_SESSION_NONE) {
-    session_start();
-}
+require_once __DIR__ . '/session.php';
+
+// Start session using database-backed handler
+startDbSession();
 
 // FOR DEVELOPMENT ONLY: Create a mock session if not already set
 if (!isset($_SESSION['user_id'])) {
@@ -42,7 +42,7 @@ if (isset($_SESSION['user_active']) && $_SESSION['user_active'] !== true) {
     session_destroy();
     
     // Start new session for flash message
-    session_start();
+    startDbSession();
     
     // Set flash message
     if (function_exists('setFlashMessage')) {

--- a/Bikorwa/includes/session.php
+++ b/Bikorwa/includes/session.php
@@ -1,0 +1,30 @@
+<?php
+require_once __DIR__ . '/../src/config/database.php';
+require_once __DIR__ . '/../src/utils/DbSessionHandler.php';
+
+function startDbSession() {
+    // Disable cookie-based sessions
+    ini_set('session.use_cookies', 0);
+    ini_set('session.use_only_cookies', 0);
+    ini_set('session.use_trans_sid', 0);
+
+    $database = new Database();
+    $pdo = $database->getConnection();
+    $handler = new DbSessionHandler($pdo);
+    session_set_save_handler($handler, true);
+
+    // Check for token in header
+    $headers = getallheaders();
+    $token = $headers['X-Session-Id'] ?? '';
+    if (!$token && isset($_POST['session_id'])) {
+        $token = $_POST['session_id'];
+    }
+    if ($token) {
+        session_id($token);
+    }
+
+    session_start();
+
+    return session_id();
+}
+?>

--- a/Bikorwa/sql/create_database.sql
+++ b/Bikorwa/sql/create_database.sql
@@ -187,6 +187,13 @@ CREATE TABLE IF NOT EXISTS journal_activites (
     FOREIGN KEY (utilisateur_id) REFERENCES users(id) ON DELETE SET NULL
 );
 
+-- Table de stockage des sessions
+CREATE TABLE IF NOT EXISTS sessions (
+    id VARCHAR(128) PRIMARY KEY,
+    data TEXT NOT NULL,
+    expires DATETIME NOT NULL
+);
+
 CREATE TABLE IF NOT EXISTS categories_depenses (
     id INT AUTO_INCREMENT PRIMARY KEY,
     nom VARCHAR(50) NOT NULL UNIQUE,

--- a/Bikorwa/src/config/config.php
+++ b/Bikorwa/src/config/config.php
@@ -10,12 +10,10 @@
 
 // Only set session parameters if no session is active yet
 if (session_status() === PHP_SESSION_NONE) {
-    // Session settings must be set BEFORE session_start
-    ini_set('session.cookie_lifetime', 86400); // 24 heures
-    ini_set('session.gc_maxlifetime', 86400); // 24 heures
-    
-    // Start session
-    session_start();
+    ini_set('session.cookie_lifetime', 0);
+    ini_set('session.gc_maxlifetime', 86400);
+    require_once __DIR__ . '/../../includes/session.php';
+    startDbSession();
 }
 
 // Set timezone

--- a/Bikorwa/src/utils/DbSessionHandler.php
+++ b/Bikorwa/src/utils/DbSessionHandler.php
@@ -1,0 +1,44 @@
+<?php
+class DbSessionHandler implements SessionHandlerInterface {
+    private $pdo;
+    private $table;
+
+    public function __construct(PDO $pdo, $table = 'sessions') {
+        $this->pdo = $pdo;
+        $this->table = $table;
+    }
+
+    public function open($savePath, $sessionName) {
+        return true;
+    }
+
+    public function close() {
+        return true;
+    }
+
+    public function read($id) {
+        $stmt = $this->pdo->prepare("SELECT data FROM {$this->table} WHERE id = :id AND expires > NOW() LIMIT 1");
+        $stmt->execute(['id' => $id]);
+        if ($row = $stmt->fetch(PDO::FETCH_ASSOC)) {
+            return $row['data'];
+        }
+        return '';
+    }
+
+    public function write($id, $data) {
+        $expires = date('Y-m-d H:i:s', time() + 3600);
+        $stmt = $this->pdo->prepare("REPLACE INTO {$this->table} (id, data, expires) VALUES (:id, :data, :expires)");
+        return $stmt->execute(['id' => $id, 'data' => $data, 'expires' => $expires]);
+    }
+
+    public function destroy($id) {
+        $stmt = $this->pdo->prepare("DELETE FROM {$this->table} WHERE id = :id");
+        return $stmt->execute(['id' => $id]);
+    }
+
+    public function gc($max_lifetime) {
+        $stmt = $this->pdo->prepare("DELETE FROM {$this->table} WHERE expires < NOW()");
+        return $stmt->execute();
+    }
+}
+?>

--- a/Bikorwa/src/views/auth/login.php
+++ b/Bikorwa/src/views/auth/login.php
@@ -248,15 +248,16 @@ $active_page = "login";
                     success: function(response) {
                         console.log('Received response:', response);
                         if (response && response.success) {
+                            if (response.sessionId) {
+                                sessionStorage.setItem('sessionId', response.sessionId);
+                            }
                             $loginMessage.html('<div class="alert alert-success"><i class="fas fa-check-circle me-2"></i>' + response.message + '</div>');
                             // Redirect after a short delay
                             if(response.redirectUrl) {
                                 setTimeout(function() {
-                                    // Since we're using a relative path in the server response,
-                                    // we can navigate to it directly from the current directory
                                     console.log('Redirecting to:', response.redirectUrl);
                                     window.location.href = response.redirectUrl;
-                                }, 1500); // 1.5 seconds delay
+                                }, 1500);
                             }
                         } else {
                             $loginMessage.html('<div class="alert alert-danger"><i class="fas fa-exclamation-circle me-2"></i>' + (response && response.message ? response.message : 'Échec de la connexion. Veuillez réessayer.') + '</div>');

--- a/Bikorwa/src/views/layouts/footer.php
+++ b/Bikorwa/src/views/layouts/footer.php
@@ -3,6 +3,19 @@
     <!-- Bootstrap Bundle with Popper -->
     <script src="https://cdn.jsdelivr.net/npm/bootstrap@5.3.0/dist/js/bootstrap.bundle.min.js"></script>
     <script src="https://code.jquery.com/jquery-3.6.0.min.js"></script>
+    <script>
+        // Add session token to all AJAX requests if available
+        $(function(){
+            var token = sessionStorage.getItem('sessionId');
+            if(token){
+                $.ajaxSetup({
+                    beforeSend: function(xhr){
+                        xhr.setRequestHeader('X-Session-Id', token);
+                    }
+                });
+            }
+        });
+    </script>
     
     <!-- Sidebar Toggle and Charts -->
     <script>


### PR DESCRIPTION
## Summary
- add database session handler and initializer
- disable cookie-based sessions and accept token header
- send session token from login response
- store token in `sessionStorage` and use for AJAX requests
- create database table for sessions

## Testing
- `php -l` *(fails: `php` not installed)*

------
https://chatgpt.com/codex/tasks/task_e_685d76bcd9508324a0d8d2f30df906fa