### PR TITLE
Fix session handler when DB fails

### DIFF
--- a/Bikorwa/includes/session.php
+++ b/Bikorwa/includes/session.php
@@ -10,11 +10,15 @@ function startDbSession() {
 
     $database = new Database();
     $pdo = $database->getConnection();
-    $handler = new DbSessionHandler($pdo);
-    session_set_save_handler($handler, true);
+    if ($pdo instanceof PDO) {
+        $handler = new DbSessionHandler($pdo);
+        session_set_save_handler($handler, true);
+    } else {
+        error_log('Unable to initialize DB session handler: connection failed');
+    }
 
     // Check for token in header
-    $headers = getallheaders();
+    $headers = function_exists('getallheaders') ? getallheaders() : [];
     $token = $headers['X-Session-Id'] ?? '';
     if (!$token && isset($_POST['session_id'])) {
         $token = $_POST['session_id'];


### PR DESCRIPTION
## Summary
- avoid fatal error if DB session handler can't connect
- handle missing getallheaders() for CLI

## Testing
- `php -l Bikorwa/includes/session.php`
- `php Bikorwa/src/api/notifications/get_alerts.php | head`

------
https://chatgpt.com/codex/tasks/task_e_685d7e381f948324ae4d4123f77afafb