### PR TITLE
Improve notifications API robustness

### DIFF
--- a/Bikorwa/src/config/database.php
+++ b/Bikorwa/src/config/database.php
@@ -25,7 +25,8 @@ class Database {
             $this->conn->exec("set names utf8");
             $this->conn->setAttribute(PDO::ATTR_ERRMODE, PDO::ERRMODE_EXCEPTION);
         } catch(PDOException $exception) {
-            echo "Erreur de connexion: " . $exception->getMessage();
+            // Avoid sending output before headers are sent
+            error_log('Database connection error: ' . $exception->getMessage());
         }
         return $this->conn;
     }


### PR DESCRIPTION
## Summary
- avoid echoing DB errors in `database.php`
- handle exceptions in `get_alerts.php` to prevent 500 responses

## Testing
- `php -l Bikorwa/src/api/notifications/get_alerts.php`


------
https://chatgpt.com/codex/tasks/task_e_685d7fc2323483249c8d3fbc27b0b7a9