### PR TITLE
Add Database class existence check

### DIFF
--- a/Bikorwa/src/controllers/AuthController.php
+++ b/Bikorwa/src/controllers/AuthController.php
@@ -11,10 +11,20 @@ class AuthController {
     
     // Constructeur
     public function __construct() {
+        // Vérifier que la classe Database est bien chargée
+        if (!class_exists('Database')) {
+            $databaseFile = __DIR__ . '/../config/database.php';
+            if (file_exists($databaseFile)) {
+                require_once $databaseFile;
+            } else {
+                throw new RuntimeException('Fichier de configuration de la base de données introuvable : ' . $databaseFile);
+            }
+        }
+
         // Connexion à la base de données
         $database = new Database();
         $this->db = $database->getConnection();
-        
+
         // Initialisation de l'authentification
         $this->auth = new Auth($this->db);
     }


### PR DESCRIPTION
## Summary
- verify that the `Database` class is loaded in `AuthController`

## Testing
- `php -l Bikorwa/src/controllers/AuthController.php` *(fails: `php` not found)*

------
https://chatgpt.com/codex/tasks/task_e_685e8f6e7b2083248102781f37a439a5