### PR TITLE
Fix login session persistence

### DIFF
--- a/Bikorwa/includes/session.php
+++ b/Bikorwa/includes/session.php
@@ -3,10 +3,6 @@ require_once __DIR__ . '/../src/config/database.php';
 require_once __DIR__ . '/../src/utils/DbSessionHandler.php';
 
 function startDbSession() {
-    // Disable cookie-based sessions
-    ini_set('session.use_cookies', 0);
-    ini_set('session.use_only_cookies', 0);
-    ini_set('session.use_trans_sid', 0);
 
     $database = new Database();
     $pdo = $database->getConnection();
@@ -27,7 +23,9 @@ function startDbSession() {
         session_id($token);
     }
 
-    session_start();
+    if (session_status() === PHP_SESSION_NONE) {
+        session_start();
+    }
 
     return session_id();
 }

--- a/Bikorwa/src/utils/DbSessionHandler.php
+++ b/Bikorwa/src/utils/DbSessionHandler.php
@@ -8,15 +8,15 @@ class DbSessionHandler implements SessionHandlerInterface {
         $this->table = $table;
     }
 
-    public function open($savePath, $sessionName) {
+    public function open($savePath, $sessionName): bool {
         return true;
     }
 
-    public function close() {
+    public function close(): bool {
         return true;
     }
 
-    public function read($id) {
+    public function read($id): string|false {
         $stmt = $this->pdo->prepare("SELECT data FROM {$this->table} WHERE id = :id AND expires > NOW() LIMIT 1");
         $stmt->execute(['id' => $id]);
         if ($row = $stmt->fetch(PDO::FETCH_ASSOC)) {
@@ -25,18 +25,18 @@ class DbSessionHandler implements SessionHandlerInterface {
         return '';
     }
 
-    public function write($id, $data) {
+    public function write($id, $data): bool {
         $expires = date('Y-m-d H:i:s', time() + 3600);
         $stmt = $this->pdo->prepare("REPLACE INTO {$this->table} (id, data, expires) VALUES (:id, :data, :expires)");
         return $stmt->execute(['id' => $id, 'data' => $data, 'expires' => $expires]);
     }
 
-    public function destroy($id) {
+    public function destroy($id): bool {
         $stmt = $this->pdo->prepare("DELETE FROM {$this->table} WHERE id = :id");
         return $stmt->execute(['id' => $id]);
     }
 
-    public function gc($max_lifetime) {
+    public function gc($max_lifetime): int|false {
         $stmt = $this->pdo->prepare("DELETE FROM {$this->table} WHERE expires < NOW()");
         return $stmt->execute();
     }

--- a/Bikorwa/src/views/auth/login.php
+++ b/Bikorwa/src/views/auth/login.php
@@ -3,10 +3,7 @@
 // Enable error reporting for debugging purposes
 error_reporting(E_ALL);
 ini_set('display_errors', 1);
-// Start session if not already started
-if (session_status() === PHP_SESSION_NONE) {
-    session_start();
-}
+// Session will be started in config.php using the custom handler
 
 // Include the configuration file to get BASE_URL
 require_once __DIR__ . '/../../../src/config/config.php';


### PR DESCRIPTION
## Summary
- remove forced cookie disabling in DB session handler
- let config handle session start in login page
- add return type hints for DbSessionHandler

## Testing
- `php -l Bikorwa/includes/session.php`
- `php -l Bikorwa/src/utils/DbSessionHandler.php`
- `php -l Bikorwa/src/views/auth/login.php`


------
https://chatgpt.com/codex/tasks/task_e_685e970bce8c8324a72046dcadfe2f00