### PR TITLE
Fix employee page login redirect

### DIFF
--- a/Bikorwa/src/views/auth/login_process.php
+++ b/Bikorwa/src/views/auth/login_process.php
@@ -42,11 +42,6 @@ function send_json_response($success, $message, $redirectUrl = null, $statusCode
 }
 
 try {
-    // Start session first
-    if (session_status() === PHP_SESSION_NONE) {
-        session_start();
-    }
-
     // Base directory of the project
     $baseDir = dirname(__DIR__, 3);
     


### PR DESCRIPTION
## Summary
- ensure DB-based sessions initialize correctly by removing premature session_start

## Testing
- `php -l Bikorwa/src/views/auth/login_process.php`

------
https://chatgpt.com/codex/tasks/task_e_685e9f0c08fc83248eca39f2621c4a77