### PR TITLE
Fix DB sessions

### DIFF
--- a/Bikorwa/includes/session.php
+++ b/Bikorwa/includes/session.php
@@ -3,6 +3,19 @@ require_once __DIR__ . '/../src/config/database.php';
 require_once __DIR__ . '/../src/utils/DbSessionHandler.php';
 
 function startDbSession() {
+    // If a session was already started using the default handler,
+    // preserve the ID and data before reinitialising with the DB handler
+    $existingId = null;
+    $existingData = [];
+
+    if (session_status() === PHP_SESSION_ACTIVE) {
+        $existingId = session_id();
+        $existingData = $_SESSION;
+        session_write_close();
+    } elseif (!empty($_COOKIE[session_name() ?? 'PHPSESSID'])) {
+        // No active session but cookie might contain an ID
+        $existingId = $_COOKIE[session_name() ?? 'PHPSESSID'];
+    }
 
     $database = new Database();
     $pdo = $database->getConnection();
@@ -13,18 +26,34 @@ function startDbSession() {
         error_log('Unable to initialize DB session handler: connection failed');
     }
 
-    // Check for token in header
+    // Disable cookies to avoid cookie-based sessions
+    ini_set('session.use_cookies', '0');
+    ini_set('session.use_only_cookies', '0');
+
+    // Check for session token in request
     $headers = function_exists('getallheaders') ? getallheaders() : [];
     $token = $headers['X-Session-Id'] ?? '';
     if (!$token && isset($_POST['session_id'])) {
         $token = $_POST['session_id'];
     }
+
+    if (!$token && $existingId) {
+        $token = $existingId;
+    }
+
     if ($token) {
         session_id($token);
     }
 
     if (session_status() === PHP_SESSION_NONE) {
         session_start();
+    }
+
+    // Restore any previously stored data
+    if (!empty($existingData)) {
+        foreach ($existingData as $key => $value) {
+            $_SESSION[$key] = $value;
+        }
     }
 
     return session_id();

--- a/Bikorwa/src/config/config.php
+++ b/Bikorwa/src/config/config.php
@@ -8,13 +8,20 @@
 // 1. BASIC CONFIGURATIONS - Must come first
 // ====================================================
 
-// Only set session parameters if no session is active yet
+// Always use the database-backed session handler
+require_once __DIR__ . '/../../includes/session.php';
+
+// Set basic session parameters when starting a fresh session
 if (session_status() === PHP_SESSION_NONE) {
     ini_set('session.cookie_lifetime', 0);
     ini_set('session.gc_maxlifetime', 86400);
-    require_once __DIR__ . '/../../includes/session.php';
-    startDbSession();
+    // Completely disable cookie-based sessions
+    ini_set('session.use_cookies', '0');
+    ini_set('session.use_only_cookies', '0');
 }
+
+// startDbSession() will gracefully migrate any active session
+startDbSession();
 
 // Set timezone
 date_default_timezone_set('Africa/Kigali');


### PR DESCRIPTION
## Summary
- gracefully switch to database-backed sessions even if a default session was started earlier
- always initialize DB-backed session in `config.php`
- disable PHP cookies and rely on header/POST tokens instead

## Testing
- `php -l Bikorwa/includes/session.php`
- `php -l Bikorwa/src/config/config.php`


------
https://chatgpt.com/codex/tasks/task_e_68610c4338d883248301f18613d5fe30