### PR TITLE
Fix login issue by creating sessions table automatically

### DIFF
--- a/Bikorwa/includes/session.php
+++ b/Bikorwa/includes/session.php
@@ -17,6 +17,21 @@ function startDbSession() {
     $database = new Database();
     $pdo = $database->getConnection();
     if ($pdo instanceof PDO) {
+        // Ensure the sessions table exists. If it doesn't, create it
+        try {
+            $exists = $pdo->query("SHOW TABLES LIKE 'sessions'")->rowCount() > 0;
+            if (!$exists) {
+                $createQuery = "CREATE TABLE IF NOT EXISTS sessions (
+                    id VARCHAR(128) PRIMARY KEY,
+                    data TEXT NOT NULL,
+                    expires DATETIME NOT NULL
+                )";
+                $pdo->exec($createQuery);
+            }
+        } catch (Exception $e) {
+            error_log('Unable to verify sessions table: ' . $e->getMessage());
+        }
+
         $handler = new DbSessionHandler($pdo);
         session_set_save_handler($handler, true);
     } else {

--- a/README.md
+++ b/README.md
@@ -1,0 +1,16 @@
+# BIKORWA SHOP Web Application
+
+This repository contains the source code for **BIKORWA SHOP**, a PHP based web application for bar management.
+
+## Installation
+
+1. **Create the database**
+   - Import `Bikorwa/sql/create_database.sql` into your MySQL server. This script creates all necessary tables including the `sessions` table used for login sessions.
+   - Optionally run `Bikorwa/sql/migration_fix_reports.sql` to add performance indexes.
+2. **Configure credentials**
+   - Update `Bikorwa/src/config/database.php` if your database credentials differ from the defaults.
+3. **Launch the application**
+   - Point your web server's document root to this repository or create a virtual host pointing to `index.php`.
+   - Navigate to `http://your-host/Bikorwa/src/views/auth/login.php` to access the login page.
+
+If you encounter errors about the `sessions` table missing, ensure the SQL scripts were executed. The application will now attempt to create the table automatically on first run.


### PR DESCRIPTION
## Summary
- ensure the DB session handler creates the `sessions` table if missing
- add a README with basic installation steps and database setup instructions

## Testing
- `php -l Bikorwa/includes/session.php` *(fails: `php: command not found`)*

------
https://chatgpt.com/codex/tasks/task_e_6861169ec2a48324b2ac5e21b7abcedd