### PR TITLE
Fix session warnings

### DIFF
--- a/Bikorwa/includes/auth_check.php
+++ b/Bikorwa/includes/auth_check.php
@@ -55,4 +55,3 @@ define('IS_STAFF', $_SESSION['user_role'] === 'receptionniste');
 
 // Update last activity timestamp to keep session alive
 $_SESSION['last_activity'] = time();
-?>

--- a/Bikorwa/includes/db.php
+++ b/Bikorwa/includes/db.php
@@ -37,4 +37,3 @@ if (!defined('BASE_URL')) {
 if (!defined('CURRENCY')) {
     define('CURRENCY', 'BIF');
 }
-?>

--- a/Bikorwa/includes/functions.php
+++ b/Bikorwa/includes/functions.php
@@ -141,4 +141,3 @@ function getFlashMessage() {
     
     return $message;
 }
-?>

--- a/Bikorwa/includes/session.php
+++ b/Bikorwa/includes/session.php
@@ -125,4 +125,3 @@ function regenerateSessionId($deleteOldSession = true) {
     }
     return false;
 }
-?>

--- a/Bikorwa/src/config/database.php
+++ b/Bikorwa/src/config/database.php
@@ -33,4 +33,3 @@ class Database {
         return $this->conn;
     }
 }
-?>

--- a/Bikorwa/src/utils/Auth.php
+++ b/Bikorwa/src/utils/Auth.php
@@ -173,4 +173,3 @@ class Auth {
         $stmt->execute();
     }
 }
-?>

--- a/Bikorwa/src/utils/DbSessionHandler.php
+++ b/Bikorwa/src/utils/DbSessionHandler.php
@@ -41,4 +41,3 @@ class DbSessionHandler implements SessionHandlerInterface {
         return $stmt->execute();
     }
 }
-?>

--- a/Bikorwa/src/utils/Request.php
+++ b/Bikorwa/src/utils/Request.php
@@ -58,4 +58,3 @@ class Request {
         return [];
     }
 }
-?>

--- a/Bikorwa/src/utils/Response.php
+++ b/Bikorwa/src/utils/Response.php
@@ -7,4 +7,3 @@ class Response {
         exit;
     }
 }
-?>


### PR DESCRIPTION
## Summary
- remove closing PHP tags from include files to prevent accidental output

## Testing
- `php -l includes/session.php` *(fails: php command not found)*

------
https://chatgpt.com/codex/tasks/task_e_6861296588cc8324a1534bcdb31abc2d