### PR TITLE
Fix session headers

### DIFF
--- a/Bikorwa/includes/session.php
+++ b/Bikorwa/includes/session.php
@@ -8,7 +8,7 @@ if (ob_get_level()) {
 }
 
 // Prevent any output
-header('Content-Type: text/plain');
+header("Content-Type: text/html; charset=UTF-8");
 
 // Initialize database connection first
 require_once __DIR__ . '/../src/config/database.php';


### PR DESCRIPTION
## Summary
- ensure session handler uses correct content type header

## Testing
- `php -S localhost:8000` *(fails: command terminated)*
- `curl -I http://localhost:8000/Bikorwa/src/views/auth/login.php`

------
https://chatgpt.com/codex/tasks/task_e_68612b28474483249d16b8aad7799d59