### PR TITLE
Fix duplicate session initialization

### DIFF
--- a/Bikorwa/includes/session.php
+++ b/Bikorwa/includes/session.php
@@ -7,8 +7,7 @@ if (ob_get_level()) {
     ob_end_clean();
 }
 
-// Prevent any output
-header("Content-Type: text/html; charset=UTF-8");
+// No default content-type header to allow flexibility for included scripts
 
 // Initialize database connection first
 require_once __DIR__ . '/../src/config/database.php';

--- a/Bikorwa/src/views/auth/login_process.php
+++ b/Bikorwa/src/views/auth/login_process.php
@@ -55,15 +55,6 @@ function send_json_response($success, $message, $redirectUrl = null, $statusCode
 }
 
 try {
-    // Initialize session first
-    if (!function_exists('startDbSession')) {
-        throw new Exception('Session handler function not found');
-    }
-
-    $sessionId = startDbSession();
-    if (!$sessionId) {
-        throw new Exception('Failed to initialize session');
-    }
 
     // Verify request method
     if ($_SERVER['REQUEST_METHOD'] !== 'POST') {


### PR DESCRIPTION
## Summary
- avoid overriding content headers in the session helper
- remove redundant call to `startDbSession` in the login process

## Testing
- `php -v` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_68613000d4dc8324a6264aaba3ae9e24