### PR TITLE
Add session debug logging

### DIFF
--- a/Bikorwa/includes/session.php
+++ b/Bikorwa/includes/session.php
@@ -76,6 +76,12 @@ SQL
     }
     $_SESSION['last_activity'] = time();
 
+    // Debugging: log and output session ID if enabled
+    if (defined('SESSION_DEBUG') && SESSION_DEBUG) {
+        error_log('Session started: ' . session_id());
+        echo "<script>console.log('Session ID: " . session_id() . "');</script>";
+    }
+
     return $session_id;
 }
 

--- a/Bikorwa/src/config/config.php
+++ b/Bikorwa/src/config/config.php
@@ -28,6 +28,11 @@ if (!defined('ROOT_PATH'))    define('ROOT_PATH', dirname(dirname(__DIR__)));
 if (!defined('SRC_PATH'))     define('SRC_PATH', ROOT_PATH . '/src');
 if (!defined('ASSETS_PATH'))  define('ASSETS_PATH', ROOT_PATH . '/assets');
 
+// Enable session debugging if needed
+if (!defined('SESSION_DEBUG')) {
+    define('SESSION_DEBUG', false);
+}
+
 // ====================================================
 // 3. ERROR HANDLING
 // ====================================================


### PR DESCRIPTION
## Summary
- provide optional `SESSION_DEBUG` constant
- log session initialization and echo session ID to browser console

## Testing
- `php -l Bikorwa/includes/session.php` *(fails: php not installed)*

------
https://chatgpt.com/codex/tasks/task_e_68613ac5ab448324825fc53974a00268