### PR TITLE
Remove database session handler

### DIFF
--- a/Bikorwa/includes/auth_check.php
+++ b/Bikorwa/includes/auth_check.php
@@ -4,10 +4,10 @@
  * This file should be included at the top of all protected pages
  */
 
-require_once __DIR__ . '/session.php';
-
-// Start session using database-backed handler
-startDbSession();
+// Start session at the beginning of each protected page
+if (session_status() === PHP_SESSION_NONE) {
+    session_start();
+}
 
 // The following block created a mock session for development purposes.
 // It granted "gestionnaire" privileges when no session existed, which caused
@@ -37,7 +37,9 @@ if (isset($_SESSION['user_active']) && $_SESSION['user_active'] !== true) {
     session_destroy();
     
     // Start new session for flash message
-    startDbSession();
+    if (session_status() === PHP_SESSION_NONE) {
+        session_start();
+    }
     
     // Set flash message
     if (function_exists('setFlashMessage')) {

--- a/Bikorwa/src/views/auth/login.php
+++ b/Bikorwa/src/views/auth/login.php
@@ -3,7 +3,10 @@
 // Enable error reporting for debugging purposes
 error_reporting(E_ALL);
 ini_set('display_errors', 1);
-// Session will be started in config.php using the custom handler
+// Start a standard PHP session
+if (session_status() === PHP_SESSION_NONE) {
+    session_start();
+}
 
 // Include the configuration file to get BASE_URL
 require_once __DIR__ . '/../../../src/config/config.php';

--- a/Bikorwa/src/views/auth/login_process.php
+++ b/Bikorwa/src/views/auth/login_process.php
@@ -19,6 +19,7 @@ header('Content-Type: application/json');
 require_once __DIR__ . '/../../../src/config/config.php';
 require_once __DIR__ . '/../../../src/config/database.php';
 require_once __DIR__ . '/../../../includes/functions.php';
+require_once __DIR__ . '/../../../includes/session.php';
 require_once __DIR__ . '/../../../src/utils/Auth.php';
 require_once __DIR__ . '/../../../src/models/User.php';
 require_once __DIR__ . '/../../../src/controllers/AuthController.php';
@@ -54,19 +55,9 @@ function send_json_response($success, $message, $redirectUrl = null, $statusCode
 }
 
 try {
-    // Initialize session if it isn't already active
-    if (!function_exists('startDbSession')) {
-        throw new Exception('Session handler function not found');
-    }
-
-    if (session_status() === PHP_SESSION_ACTIVE) {
-        $sessionId = session_id();
-    } else {
-        $sessionId = startDbSession();
-    }
-
-    if (!$sessionId) {
-        throw new Exception('Failed to initialize session');
+    // Start PHP session
+    if (session_status() === PHP_SESSION_NONE) {
+        session_start();
     }
 
     // Verify request method

--- a/Bikorwa/src/views/auth/session_debug.php
+++ b/Bikorwa/src/views/auth/session_debug.php
@@ -5,42 +5,15 @@
  */
 
 // Include your config files
-require_once 'https://uab.bumadventiste.org/Bikorwa/src/config/config.php';
+require_once __DIR__ . '/../../../src/config/config.php';
 
-// Check if database session function exists
-if (function_exists('startDbSession')) {
-    echo "✅ Database session function EXISTS<br>";
-    
-    try {
-        $sessionId = startDbSession();
-        echo "✅ Database session STARTED successfully<br>";
-        echo "Session ID: " . $sessionId . "<br>";
-        echo "Session Handler: " . session_get_save_handler() . "<br>";
-        
-        // Check if we can write to database sessions
-        $_SESSION['test'] = 'database_session_test';
-        echo "✅ Database session WRITE test successful<br>";
-        
-    } catch (Exception $e) {
-        echo "❌ Database session FAILED: " . $e->getMessage() . "<br>";
-        echo "Falling back to cookie sessions...<br>";
-        
-        if (session_status() === PHP_SESSION_NONE) {
-            session_start();
-        }
-        echo "Cookie session started. ID: " . session_id() . "<br>";
-        echo "Session Handler: " . session_get_save_handler() . "<br>";
-    }
-} else {
-    echo "❌ Database session function NOT FOUND<br>";
-    echo "Using cookie-based sessions...<br>";
-    
-    if (session_status() === PHP_SESSION_NONE) {
-        session_start();
-    }
-    echo "Cookie session started. ID: " . session_id() . "<br>";
-    echo "Session Handler: " . session_get_save_handler() . "<br>";
+// Start a normal PHP session
+if (session_status() === PHP_SESSION_NONE) {
+    session_start();
 }
+
+echo "Session started. ID: " . session_id() . "<br>";
+echo "Session Handler: " . session_module_name() . "<br>";
 
 // Display current session data
 echo "<br><strong>Current Session Data:</strong><br>";

--- a/Bikorwa/src/views/dashboard/index.php
+++ b/Bikorwa/src/views/dashboard/index.php
@@ -1,6 +1,6 @@
 <?php
 
-// Include authentication check and database-backed session
+// Include authentication check which also starts the PHP session
 require_once __DIR__ . '/../../../includes/auth_check.php';
 // Dashboard Page for BIKORWA SHOP - Gestionnaire Role
 $page_title = "Tableau de Bord - Gestionnaire";

--- a/Bikorwa/src/views/dashboard/receptionniste.php
+++ b/Bikorwa/src/views/dashboard/receptionniste.php
@@ -1,5 +1,5 @@
 <?php
-// Include authentication check and database-backed session
+// Include authentication check which also starts the PHP session
 require_once __DIR__ . '/../../../includes/auth_check.php';
 
 // Include database connection and config


### PR DESCRIPTION
## Summary
- switch to normal PHP sessions
- remove remaining calls to `startDbSession`
- ensure login page and debug page start sessions normally
- clarify session-start comments on dashboard pages

## Testing
- `php -l Bikorwa/src/views/dashboard/index.php` *(fails: command not found)*
- `php -l Bikorwa/src/views/dashboard/receptionniste.php` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_68613d7ce6d48324a3ecd57b80bda5a0