### PR TITLE
Fix login session initialization

### DIFF
--- a/Bikorwa/src/views/auth/login.php
+++ b/Bikorwa/src/views/auth/login.php
@@ -1,12 +1,7 @@
 <?php
 
-// Initialize session with proper configuration
-require_once __DIR__ . '/../../../includes/session_db_manager.php';
-require_once __DIR__ . '/../../../src/config/database.php';
-
-$database = new Database();
-$pdo = $database->getConnection();
-$sessionManager = new DatabaseSessionManager($pdo);
+// Initialize centralized session manager
+require_once __DIR__ . '/../../../includes/session.php';
 
 // Check if user is already logged in
 if ($sessionManager->isLoggedIn()) {

--- a/Bikorwa/src/views/auth/login_process.php
+++ b/Bikorwa/src/views/auth/login_process.php
@@ -14,8 +14,7 @@ header('Content-Type: application/json');
 
 // Include core configuration
 require_once __DIR__ . '/../../../src/config/config.php';
-require_once __DIR__ . '/../../../src/config/database.php';
-require_once __DIR__ . '/../../../includes/session_db_manager.php';
+require_once __DIR__ . '/../../../includes/session.php';
 
 // Log function for debugging
 function logError($message) {


### PR DESCRIPTION
## Summary
- ensure login pages use central session handler
- update login_process.php to include session.php

## Testing
- `php -v` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_68615755593483248eb4f60d368052e9