### PR TITLE
Fix login session initialization

### DIFF
--- a/Bikorwa/includes/init.php
+++ b/Bikorwa/includes/init.php
@@ -16,7 +16,7 @@ function getCurrentUser() {
     return [
         'id' => $sessionManager->getUserId(),
         'username' => $sessionManager->getUsername(),
-        'name' => $sessionManager->getUserName(),
+        'name' => $sessionManager->getFullName(),
         'role' => $sessionManager->getUserRole(),
         'active' => $sessionManager->isUserActive(),
         'logged_in' => $sessionManager->isLoggedIn()

--- a/Bikorwa/includes/session_manager.php
+++ b/Bikorwa/includes/session_manager.php
@@ -4,8 +4,8 @@
  * This file ensures consistent session handling across the entire application
  */
 
-// Prevent multiple inclusions
-if (defined('SESSION_MANAGER_LOADED') || class_exists('SessionManager')) {
+// Prevent multiple inclusions without triggering autoload
+if (defined('SESSION_MANAGER_LOADED')) {
     return;
 }
 define('SESSION_MANAGER_LOADED', true);
@@ -312,9 +312,9 @@ class SessionManager
     }
     
     /**
-     * Get current user name
+     * Get current user's full name
      */
-    public function getUserName() 
+    public function getFullName()
     {
         return $this->get('user_name');
     }

--- a/Bikorwa/src/views/auth/login.php
+++ b/Bikorwa/src/views/auth/login.php
@@ -1,12 +1,7 @@
 <?php
 
-// Initialize session with proper configuration
-require_once __DIR__ . '/../../../includes/session_db_manager.php';
-require_once __DIR__ . '/../../../src/config/database.php';
-
-$database = new Database();
-$pdo = $database->getConnection();
-$sessionManager = new DatabaseSessionManager($pdo);
+// Initialize centralized session manager
+require_once __DIR__ . '/../../../includes/session.php';
 
 // Check if user is already logged in
 if ($sessionManager->isLoggedIn()) {

--- a/Bikorwa/src/views/auth/login_process.php
+++ b/Bikorwa/src/views/auth/login_process.php
@@ -14,8 +14,7 @@ header('Content-Type: application/json');
 
 // Include core configuration
 require_once __DIR__ . '/../../../src/config/config.php';
-require_once __DIR__ . '/../../../src/config/database.php';
-require_once __DIR__ . '/../../../includes/session_db_manager.php';
+require_once __DIR__ . '/../../../includes/session.php';
 
 // Log function for debugging
 function logError($message) {


### PR DESCRIPTION
## Summary
- ensure login pages use central session handler
- update login_process.php to include session.php
- fix SessionManager double-loading and rename full name accessor

## Testing
- `php -v`
- `php -l Bikorwa/includes/session_manager.php`
- `php -l Bikorwa/includes/init.php`
- `php -l Bikorwa/src/views/auth/login.php`
- `php -l Bikorwa/src/views/auth/login_process.php`


------
https://chatgpt.com/codex/tasks/task_e_68615755593483248eb4f60d368052e9