### PR TITLE
Fix dashboard placeholder CSS

### DIFF
--- a/Bikorwa/src/views/dashboard/index.php
+++ b/Bikorwa/src/views/dashboard/index.php
@@ -216,8 +216,7 @@ require_once __DIR__.'/../layouts/header.php';
 ?>
 
 <style>
-/* Existing styles */
-{{ ... }}
+/* Custom dashboard styles */
 
 /* New spacing rules */
 .card {
@@ -236,7 +235,6 @@ require_once __DIR__.'/../layouts/header.php';
 }
 
 /* Existing animations and hover effects */
-{{ ... }}
 </style>
 
 <main id="main" class="main">


### PR DESCRIPTION
## Summary
- clean up stray template markers in dashboard style block

## Testing
- `php -l Bikorwa/src/views/dashboard/index.php` *(fails: `php: command not found`)*

------
https://chatgpt.com/codex/tasks/task_e_68615bdc183c8324833e94d65f9c8f06