### PR TITLE
Fix function name conflict

### DIFF
--- a/Bikorwa/includes/session_init.php
+++ b/Bikorwa/includes/session_init.php
@@ -45,12 +45,12 @@ function is_user_logged_in() {
            !empty($_SESSION['user_id']);
 }
 
-// Function to get current user data
-function get_current_user() {
+// Function to get logged-in user data
+function get_logged_in_user() {
     if (!is_user_logged_in()) {
         return null;
     }
-    
+
     return [
         'id' => $_SESSION['user_id'] ?? null,
         'username' => $_SESSION['username'] ?? null,


### PR DESCRIPTION
## Summary
- avoid redeclaring PHP's built-in `get_current_user()` by renaming the custom helper to `get_logged_in_user`

## Testing
- `php -v` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_6861628546d083248dc5203ac5e0cd85