### PR TITLE
Fix product search to include all products

### DIFF
--- a/Bikorwa/src/views/stock/ajustement.php
+++ b/Bikorwa/src/views/stock/ajustement.php
@@ -606,7 +606,9 @@ $(document).ready(function() {
             $.ajax({
                 url: '<?= BASE_URL ?>/src/api/produits/get_produits.php',
                 type: 'GET',
-                data: { search: search, with_stock: true },
+                // We want to search among all products regardless of their
+                // current stock level, so we don't filter by available stock
+                data: { search: search, with_stock: false },
                 dataType: 'json',
                 success: function(response) {
                     if (response.success) {


### PR DESCRIPTION
## Summary
- allow product search to fetch all products in stock adjustment page

## Testing
- `php -v` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_686243a005148324b3ab7323ecb671fa