### PR TITLE
Add selling price per batch

### DIFF
--- a/Bikorwa/sql/create_database.sql
+++ b/Bikorwa/sql/create_database.sql
@@ -67,6 +67,7 @@ CREATE TABLE IF NOT EXISTS mouvements_stock (
     quantity_remaining DECIMAL(10,2) DEFAULT NULL,
     quantite DECIMAL(10,2) NOT NULL,
     prix_unitaire DECIMAL(10,2) NOT NULL,
+    prix_vente DECIMAL(10,2) DEFAULT NULL,
     valeur_totale DECIMAL(10,2) NOT NULL,
     reference VARCHAR(100),
     date_mouvement DATETIME NOT NULL DEFAULT CURRENT_TIMESTAMP,

--- a/Bikorwa/src/ajax/get_product_batches.php
+++ b/Bikorwa/src/ajax/get_product_batches.php
@@ -58,11 +58,12 @@ try {
     }
     
     // Get batches with remaining quantity (for FIFO tracking)
-    $query = "SELECT 
+    $query = "SELECT
                 ms.id,
                 ms.quantite as quantite_initiale,
                 ms.quantity_remaining as quantite_restante,
                 ms.prix_unitaire,
+                ms.prix_vente,
                 ms.valeur_totale,
                 ms.date_mouvement,
                 ms.reference,

--- a/Bikorwa/src/api/produits/get_produits.php
+++ b/Bikorwa/src/api/produits/get_produits.php
@@ -92,12 +92,13 @@ try {
         // Get available stock with FIFO batches
         if ($with_stock && $row['quantite_stock'] > 0) {
             // Get the FIFO batches for this product
-            $fifoQuery = "SELECT 
+            $fifoQuery = "SELECT
                             ms.produit_id,
                             ms.quantity_remaining,
                             ms.prix_unitaire,
+                            ms.prix_vente,
                             ms.date_mouvement
-                           FROM 
+                           FROM
                             mouvements_stock ms
                            WHERE 
                             ms.produit_id = :id 
@@ -113,8 +114,9 @@ try {
             $batches = [];
             while ($batch = $stmtFifo->fetch(PDO::FETCH_ASSOC)) {
                 $batches[] = [
-                    'quantity' => $batch['quantity_remaining'],
-                    'prix_achat' => $batch['prix_unitaire']
+                    'quantity'   => $batch['quantity_remaining'],
+                    'prix_achat' => $batch['prix_unitaire'],
+                    'prix_vente' => $batch['prix_vente']
                 ];
             }
             

--- a/Bikorwa/src/views/stock/ajustement.php
+++ b/Bikorwa/src/views/stock/ajustement.php
@@ -58,11 +58,12 @@ if (isset($_GET['action']) && $_GET['action'] === 'get_product_batches') {
         }
         
         // Get batches with remaining quantity (for FIFO tracking)
-        $query = "SELECT 
+        $query = "SELECT
                     ms.id,
                     ms.quantite as quantite_initiale,
                     ms.quantity_remaining as quantite_restante,
                     ms.prix_unitaire,
+                    ms.prix_vente,
                     ms.valeur_totale,
                     ms.date_mouvement,
                     ms.reference,
@@ -131,6 +132,7 @@ if (isset($_GET['action']) && $_GET['action'] === 'process_adjustment') {
         $adjustment_type = isset($_POST['adjustment_type']) ? trim($_POST['adjustment_type']) : '';
         $quantity = isset($_POST['quantity']) ? floatval(str_replace(',', '.', $_POST['quantity'])) : 0;
         $price = isset($_POST['price']) ? floatval(str_replace(',', '.', $_POST['price'])) : 0;
+        $sell_price = isset($_POST['sell_price']) ? floatval(str_replace(',', '.', $_POST['sell_price'])) : 0;
         $note = isset($_POST['note']) ? trim($_POST['note']) : '';
         
         // Validate required fields
@@ -143,9 +145,14 @@ if (isset($_GET['action']) && $_GET['action'] === 'process_adjustment') {
             throw new Exception("Type d'ajustement invalide.");
         }
         
-        // If it's a stock increase, validate price
-        if ($adjustment_type === 'increase' && $price <= 0) {
-            throw new Exception("Le prix unitaire doit être supérieur à zéro pour un ajout de stock.");
+        // If it's a stock increase, validate price and selling price
+        if ($adjustment_type === 'increase') {
+            if ($price <= 0) {
+                throw new Exception("Le prix unitaire doit être supérieur à zéro pour un ajout de stock.");
+            }
+            if ($sell_price <= 0) {
+                throw new Exception("Le prix de vente doit être supérieur à zéro pour un ajout de stock.");
+            }
         }
         
         // Get product details
@@ -169,11 +176,11 @@ if (isset($_GET['action']) && $_GET['action'] === 'process_adjustment') {
             $reference = 'ADJ-IN-' . date('YmdHis');
             
             // Insert into mouvements_stock table
-            $query = "INSERT INTO mouvements_stock 
-                      (produit_id, type_mouvement, quantite, quantity_remaining, prix_unitaire, valeur_totale, 
+            $query = "INSERT INTO mouvements_stock
+                      (produit_id, type_mouvement, quantite, quantity_remaining, prix_unitaire, prix_vente, valeur_totale,
                        date_mouvement, utilisateur_id, note, reference)
-                      VALUES 
-                      (:produit_id, 'entree', :quantite, :quantity_remaining, :prix_unitaire, :valeur_totale, 
+                      VALUES
+                      (:produit_id, 'entree', :quantite, :quantity_remaining, :prix_unitaire, :prix_vente, :valeur_totale,
                        NOW(), :utilisateur_id, :note, :reference)";
             
             $stmt = $pdo->prepare($query);
@@ -182,6 +189,7 @@ if (isset($_GET['action']) && $_GET['action'] === 'process_adjustment') {
                 'quantite' => $quantity,
                 'quantity_remaining' => $quantity, // Full quantity available initially
                 'prix_unitaire' => $price,
+                'prix_vente' => $sell_price,
                 'valeur_totale' => $valeur_totale,
                 'utilisateur_id' => $_SESSION['user_id'],
                 'note' => $note ?: 'Ajustement de stock (Ajout)',
@@ -459,6 +467,17 @@ include('../layouts/header.php');
                                                 </div>
                                             </div>
                                         </div>
+                                        <div class="col-md-6">
+                                            <div class="form-group" id="sell-price-group">
+                                                <label for="sell_price">Prix de vente <span class="text-danger">*</span></label>
+                                                <div class="input-group">
+                                                    <input type="text" class="form-control" id="sell_price" name="sell_price">
+                                                    <div class="input-group-append">
+                                                        <span class="input-group-text">BIF</span>
+                                                    </div>
+                                                </div>
+                                            </div>
+                                        </div>
                                     </div>
                                     
                                     <div class="form-group">
@@ -504,6 +523,8 @@ include('../layouts/header.php');
                         
                         <h6 class="font-weight-bold" id="preview-price-label">Prix unitaire</h6>
                         <p id="preview-price">-</p>
+                        <h6 class="font-weight-bold" id="preview-sell-price-label">Prix de vente</h6>
+                        <p id="preview-sell-price">-</p>
                     </div>
                 </div>
                 
@@ -698,6 +719,7 @@ $(document).ready(function() {
         const adjustmentType = $('#adjustment-type').val();
         const quantity = $('#quantity').val();
         const price = $('#price').val();
+        const sellPrice = $('#sell_price').val();
         const note = $('#note').val();
         
         // Validate
@@ -711,9 +733,15 @@ $(document).ready(function() {
             return;
         }
         
-        if (adjustmentType === 'increase' && (!price || parseFloat(price) <= 0)) {
-            showNotification('danger', 'Veuillez entrer un prix unitaire valide.');
-            return;
+        if (adjustmentType === 'increase') {
+            if (!price || parseFloat(price) <= 0) {
+                showNotification('danger', 'Veuillez entrer un prix unitaire valide.');
+                return;
+            }
+            if (!sellPrice || parseFloat(sellPrice) <= 0) {
+                showNotification('danger', 'Veuillez entrer un prix de vente valide.');
+                return;
+            }
         }
         
         // Update preview modal
@@ -724,9 +752,13 @@ $(document).ready(function() {
         if (adjustmentType === 'increase') {
             $('#preview-price-label').show();
             $('#preview-price').text(formatCurrency(price) + ' BIF').show();
+            $('#preview-sell-price-label').show();
+            $('#preview-sell-price').text(formatCurrency(sellPrice) + ' BIF').show();
         } else {
             $('#preview-price-label').hide();
             $('#preview-price').hide();
+            $('#preview-sell-price-label').hide();
+            $('#preview-sell-price').hide();
         }
         
         $('#preview-note').text(note || '-');

--- a/Bikorwa/src/views/ventes/nouvelle.php
+++ b/Bikorwa/src/views/ventes/nouvelle.php
@@ -170,12 +170,13 @@ if (isset($_GET['action']) && $_GET['action'] === 'get_produits') {
             // Get available stock with FIFO batches
             if ($with_stock && $row['quantite_stock'] > 0) {
                 // Get the FIFO batches for this product
-                $fifoQuery = "SELECT 
+                $fifoQuery = "SELECT
                                 ms.produit_id,
                                 ms.quantity_remaining,
                                 ms.prix_unitaire,
+                                ms.prix_vente,
                                 ms.date_mouvement
-                               FROM 
+                               FROM
                                 mouvements_stock ms
                                WHERE 
                                 ms.produit_id = :id 
@@ -191,8 +192,9 @@ if (isset($_GET['action']) && $_GET['action'] === 'get_produits') {
                 $batches = [];
                 while ($batch = $stmtFifo->fetch(PDO::FETCH_ASSOC)) {
                     $batches[] = [
-                        'quantity' => $batch['quantity_remaining'],
-                        'prix_achat' => $batch['prix_unitaire']
+                        'quantity'   => $batch['quantity_remaining'],
+                        'prix_achat' => $batch['prix_unitaire'],
+                        'prix_vente' => $batch['prix_vente']
                     ];
                 }
                 
@@ -635,12 +637,13 @@ if (isset($_GET['action']) && $_GET['action'] === 'get_product_batches') {
         }
         
         // Get FIFO batches for the product
-        $batchQuery = "SELECT 
-                        ms.id, 
-                        ms.date_mouvement, 
-                        ms.quantite as quantite_initiale, 
-                        ms.quantity_remaining as quantite_restante, 
+        $batchQuery = "SELECT
+                        ms.id,
+                        ms.date_mouvement,
+                        ms.quantite as quantite_initiale,
+                        ms.quantity_remaining as quantite_restante,
                         ms.prix_unitaire,
+                        ms.prix_vente,
                         ms.reference
                        FROM mouvements_stock ms
                        WHERE ms.produit_id = :product_id 


### PR DESCRIPTION
## Summary
- store selling price per batch in `mouvements_stock`
- expose selling price in batch APIs
- allow entering and previewing selling price during stock adjustment

## Testing
- `php -l Bikorwa/src/ajax/get_product_batches.php` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_68656abca5788324adf1ddc53302b6b6