### PR TITLE
Fix category pre-fill in edit modal

### DIFF
--- a/Bikorwa/src/views/stock/inventaire.php
+++ b/Bikorwa/src/views/stock/inventaire.php
@@ -533,8 +533,9 @@ try {
     }
     
     $stmt = $pdo->prepare("
-        SELECT 
+        SELECT
             p.id, p.code, p.nom, p.description, p.unite_mesure, p.actif,
+            p.categorie_id,
             c.nom as categorie_nom,
             COALESCE(s.quantite, 0) as quantite_stock,
             s.date_mise_a_jour,


### PR DESCRIPTION
## Summary
- include `p.categorie_id` in inventory query to populate edit modal

## Testing
- `php` syntax check *(failed: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_6865704df478832489baad64bea35e0f