### PR TITLE
Fix session handling for gestionnaire pages

### DIFF
--- a/Bikorwa/src/views/dashboard/index.php
+++ b/Bikorwa/src/views/dashboard/index.php
@@ -1,20 +1,9 @@
 <?php
-session_start();
-
-require_once __DIR__ . '/../../../src/config/config.php';
+require_once __DIR__ . '/../../../includes/init.php';
 require_once __DIR__ . '/../../../src/config/database.php';
 
-// Check if user is logged in
-if (!isset($_SESSION['logged_in']) || $_SESSION['logged_in'] !== true) {
-    header('Location: ' . BASE_URL . '/src/views/auth/login.php');
-    exit();
-}
-
-// Check user role
-if ($_SESSION['role'] !== 'gestionnaire') {
-    header('Location: ' . BASE_URL . '/src/views/auth/login.php');
-    exit();
-}
+// Ensure only gestionnaires access this page
+requireManager();
 
 // Dashboard Page for BIKORWA SHOP - Gestionnaire Role
 $page_title = "Tableau de Bord - Gestionnaire";

--- a/Bikorwa/src/views/rapports/all_activities.php
+++ b/Bikorwa/src/views/rapports/all_activities.php
@@ -3,14 +3,11 @@
 $page_title = "Toutes les Activités";
 $active_page = "rapports";
 
-require_once __DIR__.'/../../../src/config/config.php';
-require_once __DIR__.'/../../../src/config/database.php';
-require_once __DIR__.'/../../../src/utils/Auth.php';
+require_once __DIR__ . '/../../../includes/init.php';
+require_once __DIR__ . '/../../../src/config/database.php';
 
-if (!isset($_SESSION['user_id']) || $_SESSION['role'] !== 'gestionnaire') {
-    header('Location: ' . BASE_URL . '/src/views/auth/login.php');
-    exit;
-}
+// Accessible uniquement aux gestionnaires
+requireManager();
 
 $database = new Database();
 $pdo = $database->getConnection();

--- a/Bikorwa/src/views/rapports/rapports_inventaire.php
+++ b/Bikorwa/src/views/rapports/rapports_inventaire.php
@@ -3,15 +3,11 @@
 $page_title = "Suivi des Stocks";
 $active_page = "rapports";
 
-require_once __DIR__.'/../../../src/config/config.php';
-require_once __DIR__.'/../../../src/config/database.php';
-require_once __DIR__.'/../../../src/utils/Auth.php';
+require_once __DIR__ . '/../../../includes/init.php';
+require_once __DIR__ . '/../../../src/config/database.php';
 
-// Vérification des permissions
-if (!isset($_SESSION['user_id']) || $_SESSION['role'] !== 'gestionnaire') {
-    header('Location: ' . BASE_URL . '/src/views/auth/login.php');
-    exit;
-}
+// Seuls les gestionnaires peuvent accéder à cette page
+requireManager();
 
 // Connexion à la base
 $database = new Database();
@@ -76,7 +72,7 @@ try {
 }
 
 // Inclusion du header
-require_once __DIR__.'/../../../src/views/layouts/header.php';
+require_once __DIR__ . '/../layouts/header.php';
 ?>
 
 <script src="https://code.jquery.com/jquery-3.6.0.min.js"></script>

--- a/Bikorwa/src/views/rapports/rapports_ventes.php
+++ b/Bikorwa/src/views/rapports/rapports_ventes.php
@@ -3,13 +3,11 @@
 $page_title = "Rapports de Ventes";
 $active_page = "rapports";
 
-// Start session if not already started
-if (session_status() === PHP_SESSION_NONE) {
-    session_start();
-}
+require_once __DIR__ . '/../../../includes/init.php';
+require_once __DIR__ . '/../../../src/config/database.php';
 
-require_once __DIR__.'/../../../src/config/config.php';
-require_once __DIR__.'/../../../src/config/database.php';
+// Ensure only gestionnaires access this page
+requireManager();
 
 // Initialize database connection
 $database = new Database();
@@ -18,12 +16,6 @@ $pdo = $database->getConnection();
 // Check if database connection is successful
 if (!$pdo) {
     die("Erreur de connexion à la base de données");
-}
-
-// Check if user is logged in and has gestionnaire role
-if (!isset($_SESSION['user_id']) || !isset($_SESSION['role']) || $_SESSION['role'] !== 'gestionnaire') {
-    header('Location: ../../auth/login.php');
-    exit;
 }
 
 // Get date filter parameters with defaults

--- a/Bikorwa/src/views/stock/delete_supply.php
+++ b/Bikorwa/src/views/stock/delete_supply.php
@@ -1,13 +1,12 @@
 <?php
-require_once __DIR__ . '/../../includes/config.php';
+require_once __DIR__ . '/../../../includes/init.php';
+require_once __DIR__ . '/../../../src/config/database.php';
 
-// Check permissions
-if ($_SESSION['role'] !== 'gestionnaire') {
-    echo json_encode(['success' => false, 'message' => 'Permission denied']);
-    exit;
-}
+// Only gestionnaires can perform this action
+requireManager();
 
-$conn = require __DIR__ . '/../../includes/db.php';
+$database = new Database();
+$pdo = $database->getConnection();
 
 $id = $_POST['id'] ?? null;
 
@@ -18,7 +17,7 @@ if (!$id) {
 
 // Delete supply entry
 $query = "DELETE FROM mouvements_stock WHERE id = ?";
-$stmt = $conn->prepare($query);
+$stmt = $pdo->prepare($query);
 $success = $stmt->execute([$id]);
 
 if ($success) {

--- a/Bikorwa/src/views/stock/edit_supply.php
+++ b/Bikorwa/src/views/stock/edit_supply.php
@@ -1,15 +1,13 @@
 <?php
-require_once __DIR__ . '/../../includes/header.php';
-require_once __DIR__ . '/../../includes/sidebar.php';
+require_once __DIR__ . '/../../../includes/init.php';
+require_once __DIR__ . '/../../../src/config/database.php';
 
-// Check permissions
-if ($_SESSION['role'] !== 'gestionnaire') {
-    header('Location: ' . BASE_URL . '/src/views/dashboard/index.php');
-    exit;
-}
+// Only gestionnaires can access this page
+requireManager();
 
 // Database connection
-$conn = require __DIR__ . '/../../includes/db.php';
+$database = new Database();
+$pdo = $database->getConnection();
 
 // Get supply entry ID
 $id = $_GET['id'] ?? null;
@@ -21,7 +19,7 @@ if (!$id) {
 
 // Fetch entry data
 $query = "SELECT * FROM mouvements_stock WHERE id = ?";
-$stmt = $conn->prepare($query);
+$stmt = $pdo->prepare($query);
 $stmt->execute([$id]);
 $entry = $stmt->fetch(PDO::FETCH_ASSOC);
 
@@ -32,9 +30,11 @@ if (!$entry) {
 
 // Fetch products
 $products_query = "SELECT id, nom FROM produits ORDER BY nom";
-$products_stmt = $conn->prepare($products_query);
+$products_stmt = $pdo->prepare($products_query);
 $products_stmt->execute();
 $products = $products_stmt->fetchAll(PDO::FETCH_ASSOC);
+
+require_once __DIR__ . '/../layouts/header.php';
 ?>
 
 <div class="content">

--- a/Bikorwa/src/views/stock/get_date_supplies.php
+++ b/Bikorwa/src/views/stock/get_date_supplies.php
@@ -1,9 +1,12 @@
 <?php
-// Start or resume session
+require_once __DIR__ . '/../../../includes/init.php';
+require_once __DIR__ . '/../../../src/config/database.php';
+
+// Optional: support session ID passed via POST
 if (isset($_POST['PHPSESSID'])) {
     session_id($_POST['PHPSESSID']);
+    $sessionManager->startSession();
 }
-session_start();
 
 // Enhanced debug logging
 error_log("=== GET DATE SUPPLIES ACCESS ===");
@@ -12,15 +15,17 @@ error_log("Session Data: " . print_r($_SESSION, true));
 
 // Check permissions
 $allowedRoles = ['gestionnaire', 'admin'];
-if (!isset($_SESSION['role']) || !in_array(strtolower($_SESSION['role']), $allowedRoles)) {
-    error_log("ACCESS DENIED - Role: " . ($_SESSION['role'] ?? 'Not Set'));
+requireAuth();
+if (!in_array(strtolower($sessionManager->getUserRole()), $allowedRoles)) {
+    error_log("ACCESS DENIED - Role: " . $sessionManager->getUserRole());
     http_response_code(403);
-    echo json_encode(['success' => false, 'message' => 'Accès non autorisé', 'debug' => ['session' => $_SESSION]]);
+    echo json_encode(['success' => false, 'message' => 'Accès non autorisé']);
     exit;
 }
 
-// Include database connection
-require_once __DIR__ . '/../../../includes/db.php';
+// Database connection
+$database = new Database();
+$pdo = $database->getConnection();
 
 // Set content type to JSON
 header('Content-Type: application/json');

--- a/Bikorwa/src/views/stock/historique_approvisionnement.php
+++ b/Bikorwa/src/views/stock/historique_approvisionnement.php
@@ -1,8 +1,6 @@
 <?php
-// Start session if not already started
-if (session_status() === PHP_SESSION_NONE) {
-    session_start();
-}
+require_once __DIR__ . '/../../../includes/init.php';
+require_once __DIR__ . '/../../../src/config/database.php';
 
 // Enhanced debug logging
 error_log("=== STOCK HISTORY ACCESS ===");
@@ -11,19 +9,18 @@ error_log("Session Data: " . print_r($_SESSION, true));
 error_log("Request Method: " . $_SERVER['REQUEST_METHOD']);
 error_log("Request Data: " . print_r($_REQUEST, true));
 
-// Include config first to get BASE_URL
-require_once __DIR__ . '/../../config/config.php';
-
-// Enhanced role check
+// Role check (gestionnaire or admin)
 $allowedRoles = ['gestionnaire', 'admin'];
-if (!isset($_SESSION['role']) || !in_array(strtolower($_SESSION['role']), $allowedRoles)) {
-    error_log("Access Denied - Role: " . ($_SESSION['role'] ?? 'Not Set'));
+requireAuth();
+if (!in_array(strtolower($sessionManager->getUserRole()), $allowedRoles)) {
+    error_log("Access Denied - Role: " . $sessionManager->getUserRole());
     header('Location: ' . BASE_URL . '/src/views/auth/login.php?reason=unauthorized');
     exit;
 }
 
-// Include database connection
-require_once __DIR__ . '/../../../includes/db.php';
+// Database connection
+$database = new Database();
+$pdo = $database->getConnection();
 ?>
 <!DOCTYPE html>
 <html lang="fr">

--- a/Bikorwa/src/views/stock/update_supply.php
+++ b/Bikorwa/src/views/stock/update_supply.php
@@ -1,13 +1,12 @@
 <?php
-require_once __DIR__ . '/../../includes/config.php';
+require_once __DIR__ . '/../../../includes/init.php';
+require_once __DIR__ . '/../../../src/config/database.php';
 
-// Check permissions
-if ($_SESSION['role'] !== 'gestionnaire') {
-    echo json_encode(['success' => false, 'message' => 'Permission denied']);
-    exit;
-}
+// Only gestionnaires can update supply entries
+requireManager();
 
-$conn = require __DIR__ . '/../../includes/db.php';
+$database = new Database();
+$pdo = $database->getConnection();
 
 $id = $_POST['id'] ?? null;
 
@@ -34,7 +33,7 @@ $query = "UPDATE mouvements_stock SET
     note = ? 
 WHERE id = ?";
 
-$stmt = $conn->prepare($query);
+$stmt = $pdo->prepare($query);
 $success = $stmt->execute([
     $produit_id,
     $quantite,


### PR DESCRIPTION
## Summary
- Use common session initializer and manager requirement across dashboard, reports, and stock management pages
- Replace direct `$_SESSION` access with session manager helpers
- Ensure stock-related API endpoints validate role and database connection correctly

## Testing
- `php -l Bikorwa/src/views/dashboard/index.php Bikorwa/src/views/rapports/rapports_ventes.php Bikorwa/src/views/rapports/rapports_inventaire.php Bikorwa/src/views/rapports/all_activities.php Bikorwa/src/views/stock/delete_supply.php Bikorwa/src/views/stock/edit_supply.php Bikorwa/src/views/stock/update_supply.php Bikorwa/src/views/stock/inventaire.php Bikorwa/src/views/stock/historique_approvisionnement.php Bikorwa/src/views/stock/get_date_supplies.php`


------
https://chatgpt.com/codex/tasks/task_e_688b61de43988324be09564e66e3c9b4