### PR TITLE
Revert session handling to use $_SESSION['role']

### DIFF
--- a/Bikorwa/src/views/stock/backups/inventaire.php.bak
+++ b/Bikorwa/src/views/stock/backups/inventaire.php.bak
@@ -23,7 +23,7 @@ $page_title = "Inventaire";
 $active_page = "stock";
 
 // Check if user has gestionnaire role
-$isGestionnaire = isset($_SESSION['user_role']) && $_SESSION['user_role'] === 'gestionnaire';
+$isGestionnaire = isset($_SESSION['role']) && $_SESSION['role'] === 'gestionnaire';
 
 // Process form actions
 $message = "";


### PR DESCRIPTION
## Summary
- Revert session manager usage and restore direct `$_SESSION['role']` checks on dashboard, reports, and stock pages
- Align the inventory backup script with the same `$_SESSION['role']` key

## Testing
- `php -l Bikorwa/src/views/dashboard/index.php Bikorwa/src/views/rapports/rapports_ventes.php Bikorwa/src/views/rapports/rapports_inventaire.php Bikorwa/src/views/rapports/all_activities.php Bikorwa/src/views/stock/delete_supply.php Bikorwa/src/views/stock/edit_supply.php Bikorwa/src/views/stock/update_supply.php Bikorwa/src/views/stock/inventaire.php Bikorwa/src/views/stock/historique_approvisionnement.php Bikorwa/src/views/stock/get_date_supplies.php`
- `php -l Bikorwa/src/views/stock/backups/inventaire.php.bak`


------
https://chatgpt.com/codex/tasks/task_e_688b61de43988324be09564e66e3c9b4