### PR TITLE
Allow admin operations in stock management

### DIFF
--- a/Bikorwa/src/views/stock/delete_supply.php
+++ b/Bikorwa/src/views/stock/delete_supply.php
@@ -1,13 +1,19 @@
 <?php
-require_once __DIR__ . '/../../includes/config.php';
+// Start session if needed
+if (session_status() === PHP_SESSION_NONE) {
+    session_start();
+}
 
-// Check permissions
-if ($_SESSION['role'] !== 'gestionnaire') {
-    echo json_encode(['success' => false, 'message' => 'Permission denied']);
+require_once __DIR__ . '/../../config/config.php';
+
+// Check permissions (allow gestionnaire and admin)
+$allowedRoles = ['gestionnaire', 'admin'];
+if (!isset($_SESSION['role']) || !in_array(strtolower($_SESSION['role']), $allowedRoles)) {
+    echo json_encode(['success' => false, 'message' => 'Accès non autorisé']);
     exit;
 }
 
-$conn = require __DIR__ . '/../../includes/db.php';
+require_once __DIR__ . '/../../../includes/db.php';
 
 $id = $_POST['id'] ?? null;
 
@@ -18,7 +24,7 @@ if (!$id) {
 
 // Delete supply entry
 $query = "DELETE FROM mouvements_stock WHERE id = ?";
-$stmt = $conn->prepare($query);
+$stmt = $pdo->prepare($query);
 $success = $stmt->execute([$id]);
 
 if ($success) {

--- a/Bikorwa/src/views/stock/edit_supply.php
+++ b/Bikorwa/src/views/stock/edit_supply.php
@@ -1,15 +1,21 @@
 <?php
-require_once __DIR__ . '/../../includes/header.php';
-require_once __DIR__ . '/../../includes/sidebar.php';
+// Start session if needed
+if (session_status() === PHP_SESSION_NONE) {
+    session_start();
+}
 
-// Check permissions
-if ($_SESSION['role'] !== 'gestionnaire') {
-    header('Location: ' . BASE_URL . '/src/views/dashboard/index.php');
+// Application config
+require_once __DIR__ . '/../../config/config.php';
+
+// Role check (allow gestionnaire and admin)
+$allowedRoles = ['gestionnaire', 'admin'];
+if (!isset($_SESSION['role']) || !in_array(strtolower($_SESSION['role']), $allowedRoles)) {
+    header('Location: ' . BASE_URL . '/src/views/auth/login.php?reason=unauthorized');
     exit;
 }
 
 // Database connection
-$conn = require __DIR__ . '/../../includes/db.php';
+require_once __DIR__ . '/../../../includes/db.php';
 
 // Get supply entry ID
 $id = $_GET['id'] ?? null;
@@ -21,7 +27,7 @@ if (!$id) {
 
 // Fetch entry data
 $query = "SELECT * FROM mouvements_stock WHERE id = ?";
-$stmt = $conn->prepare($query);
+$stmt = $pdo->prepare($query);
 $stmt->execute([$id]);
 $entry = $stmt->fetch(PDO::FETCH_ASSOC);
 
@@ -32,11 +38,12 @@ if (!$entry) {
 
 // Fetch products
 $products_query = "SELECT id, nom FROM produits ORDER BY nom";
-$products_stmt = $conn->prepare($products_query);
+$products_stmt = $pdo->prepare($products_query);
 $products_stmt->execute();
 $products = $products_stmt->fetchAll(PDO::FETCH_ASSOC);
 ?>
 
+<?php require_once __DIR__ . '/../layouts/header.php'; ?>
 <div class="content">
     <div class="container-fluid">
         <div class="row">
@@ -100,4 +107,4 @@ $products = $products_stmt->fetchAll(PDO::FETCH_ASSOC);
     </div>
 </div>
 
-<?php require_once __DIR__ . '/../../includes/footer.php'; ?>
+<?php require_once __DIR__ . '/../layouts/footer.php'; ?>

--- a/Bikorwa/src/views/stock/update_supply.php
+++ b/Bikorwa/src/views/stock/update_supply.php
@@ -1,13 +1,19 @@
 <?php
-require_once __DIR__ . '/../../includes/config.php';
+// Start session if needed
+if (session_status() === PHP_SESSION_NONE) {
+    session_start();
+}
 
-// Check permissions
-if ($_SESSION['role'] !== 'gestionnaire') {
-    echo json_encode(['success' => false, 'message' => 'Permission denied']);
+require_once __DIR__ . '/../../config/config.php';
+
+// Check permissions (allow gestionnaire and admin)
+$allowedRoles = ['gestionnaire', 'admin'];
+if (!isset($_SESSION['role']) || !in_array(strtolower($_SESSION['role']), $allowedRoles)) {
+    echo json_encode(['success' => false, 'message' => 'Accès non autorisé']);
     exit;
 }
 
-$conn = require __DIR__ . '/../../includes/db.php';
+require_once __DIR__ . '/../../../includes/db.php';
 
 $id = $_POST['id'] ?? null;
 
@@ -25,16 +31,16 @@ $reference = $_POST['reference'] ?? null;
 $note = $_POST['note'] ?? null;
 
 // Update supply entry
-$query = "UPDATE mouvements_stock SET 
-    produit_id = ?, 
-    quantite = ?, 
-    prix_unitaire = ?, 
-    date_mouvement = ?, 
-    reference = ?, 
-    note = ? 
+$query = "UPDATE mouvements_stock SET
+    produit_id = ?,
+    quantite = ?,
+    prix_unitaire = ?,
+    date_mouvement = ?,
+    reference = ?,
+    note = ?
 WHERE id = ?";
 
-$stmt = $conn->prepare($query);
+$stmt = $pdo->prepare($query);
 $success = $stmt->execute([
     $produit_id,
     $quantite,


### PR DESCRIPTION
## Summary
- fix stock edit page to allow both gestionnaire and admin roles and load correct resources
- permit admin role to delete supply entries
- permit admin role to update supply entries

## Testing
- `php -l Bikorwa/src/views/stock/edit_supply.php`
- `php -l Bikorwa/src/views/stock/delete_supply.php`
- `php -l Bikorwa/src/views/stock/update_supply.php`


------
https://chatgpt.com/codex/tasks/task_e_688ba4adcb5c8324b6e17a23f6f00695