### PR TITLE
Allow admin operations in stock management

### DIFF
--- a/Bikorwa/src/views/stock/delete_supply.php
+++ b/Bikorwa/src/views/stock/delete_supply.php
@@ -1,28 +1,35 @@
 <?php
-require_once __DIR__ . '/../../includes/config.php';
+// Start session if needed
+if (session_status() === PHP_SESSION_NONE) {
+    session_start();
+}
 
-// Check permissions
-if ($_SESSION['role'] !== 'gestionnaire') {
-    echo json_encode(['success' => false, 'message' => 'Permission denied']);
+require_once __DIR__ . '/../../config/config.php';
+
+// Check authentication and permissions
+$allowedRoles = ['gestionnaire', 'admin'];
+if (!isset($_SESSION['user_id']) || !isset($_SESSION['role']) ||
+    !in_array(strtolower($_SESSION['role']), $allowedRoles)) {
+    header('Location: ' . BASE_URL . '/src/views/auth/login.php?reason=unauthorized');
     exit;
 }
 
-$conn = require __DIR__ . '/../../includes/db.php';
+require_once __DIR__ . '/../../../includes/db.php';
 
 $id = $_POST['id'] ?? null;
 
 if (!$id) {
-    echo json_encode(['success' => false, 'message' => 'ID invalide']);
+    header('Location: historique_approvisionnement.php?error=invalid');
     exit;
 }
 
 // Delete supply entry
 $query = "DELETE FROM mouvements_stock WHERE id = ?";
-$stmt = $conn->prepare($query);
+$stmt = $pdo->prepare($query);
 $success = $stmt->execute([$id]);
 
 if ($success) {
-    echo json_encode(['success' => true]);
+    header('Location: historique_approvisionnement.php?status=deleted');
 } else {
-    echo json_encode(['success' => false, 'message' => 'Erreur de suppression']);
+    header('Location: historique_approvisionnement.php?error=delete');
 }


### PR DESCRIPTION
## Summary
- fix stock edit page to allow both gestionnaire and admin roles and load correct resources
- permit admin role to delete supply entries
- permit admin role to update supply entries
- redirect unauthorized stock actions to login and route form submissions via absolute URLs

## Testing
- `php -l Bikorwa/src/views/stock/delete_supply.php`
- `php -l Bikorwa/src/views/stock/edit_supply.php`
- `php -l Bikorwa/src/views/stock/update_supply.php`


------
https://chatgpt.com/codex/tasks/task_e_688ba4adcb5c8324b6e17a23f6f00695