### PR TITLE
Handle session ID for stock actions

### DIFF
--- a/Bikorwa/src/views/stock/approvisionnement.php
+++ b/Bikorwa/src/views/stock/approvisionnement.php
@@ -17,7 +17,8 @@ $active_page = "stock";
         <h6 class="m-0 font-weight-bold">Enregistrer un nouvel approvisionnement</h6>
     </div>
     <div class="card-body">
-        <form id="approForm" action="/stock/save_approvisionnement.php" method="post">
+        <form id="approForm" action="<?= BASE_URL ?>/src/views/stock/save_approvisionnement.php" method="post">
+            <input type="hidden" name="PHPSESSID" value="<?= session_id() ?>">
             <div class="row mb-4">
                 <div class="col-md-6">
                     <div class="mb-3">

--- a/Bikorwa/src/views/stock/delete_supply.php
+++ b/Bikorwa/src/views/stock/delete_supply.php
@@ -1,8 +1,14 @@
 <?php
-// Start session if needed
+// Start or resume session using provided PHPSESSID if available
+if (isset($_POST['PHPSESSID'])) {
+    session_id($_POST['PHPSESSID']);
+}
 if (session_status() === PHP_SESSION_NONE) {
     session_start();
 }
+
+// Return JSON response
+header('Content-Type: application/json');
 
 require_once __DIR__ . '/../../config/config.php';
 

--- a/Bikorwa/src/views/stock/edit_supply.php
+++ b/Bikorwa/src/views/stock/edit_supply.php
@@ -53,8 +53,9 @@ $products = $products_stmt->fetchAll(PDO::FETCH_ASSOC);
                         <h3 class="card-title">Modifier l'entrée d'approvisionnement</h3>
                     </div>
                     <div class="card-body">
-                        <form id="edit-supply-form" method="POST" action="update_supply.php">
+                        <form id="edit-supply-form" method="POST" action="<?= BASE_URL ?>/src/views/stock/update_supply.php">
                             <input type="hidden" name="id" value="<?= $entry['id'] ?>">
+                            <input type="hidden" name="PHPSESSID" value="<?= session_id() ?>">
                             
                             <div class="form-group">
                                 <label for="produit_id">Produit</label>

--- a/Bikorwa/src/views/stock/historique_approvisionnement.php
+++ b/Bikorwa/src/views/stock/historique_approvisionnement.php
@@ -443,14 +443,20 @@ document.addEventListener('DOMContentLoaded', function() {
                 // Submit form for better reliability
                 const form = document.createElement('form');
                 form.method = 'POST';
-                form.action = 'delete_supply.php';
-                
-                const input = document.createElement('input');
-                input.type = 'hidden';
-                input.name = 'id';
-                input.value = id;
-                
-                form.appendChild(input);
+                form.action = '<?= BASE_URL ?>/src/views/stock/delete_supply.php';
+
+                const idInput = document.createElement('input');
+                idInput.type = 'hidden';
+                idInput.name = 'id';
+                idInput.value = id;
+
+                const sessionInput = document.createElement('input');
+                sessionInput.type = 'hidden';
+                sessionInput.name = 'PHPSESSID';
+                sessionInput.value = '<?= session_id() ?>';
+
+                form.appendChild(idInput);
+                form.appendChild(sessionInput);
                 document.body.appendChild(form);
                 form.submit();
             }
@@ -500,7 +506,7 @@ document.addEventListener('DOMContentLoaded', function() {
         formData.append('date', date);
         formData.append('PHPSESSID', '<?= session_id() ?>');
         
-        fetch('get_date_supplies.php', {
+        fetch('<?= BASE_URL ?>/src/views/stock/get_date_supplies.php', {
             method: 'POST',
             body: formData,
             credentials: 'same-origin'

--- a/Bikorwa/src/views/stock/update_supply.php
+++ b/Bikorwa/src/views/stock/update_supply.php
@@ -1,8 +1,14 @@
 <?php
-// Start session if needed
+// Start or resume session using provided PHPSESSID if available
+if (isset($_POST['PHPSESSID'])) {
+    session_id($_POST['PHPSESSID']);
+}
 if (session_status() === PHP_SESSION_NONE) {
     session_start();
 }
+
+// Return JSON responses
+header('Content-Type: application/json');
 
 require_once __DIR__ . '/../../config/config.php';
 


### PR DESCRIPTION
## Summary
- Ensure stock endpoints resume sessions using posted PHPSESSID
- Send PHPSESSID and absolute URLs from stock views to avoid unauthorized errors

## Testing
- `php -l Bikorwa/src/views/stock/delete_supply.php`
- `php -l Bikorwa/src/views/stock/update_supply.php`
- `php -l Bikorwa/src/views/stock/historique_approvisionnement.php`
- `php -l Bikorwa/src/views/stock/edit_supply.php`
- `php -l Bikorwa/src/views/stock/approvisionnement.php`


------
https://chatgpt.com/codex/tasks/task_e_688babb3cdc88324bfdb9c1310198489