### PR TITLE
Start session in product API to respect authentication

### DIFF
--- a/Bikorwa/src/api/produits/get_produits.php
+++ b/Bikorwa/src/api/produits/get_produits.php
@@ -1,6 +1,11 @@
 <?php
 // API endpoint to get products with stock information
 
+// Start session if not already started
+if (session_status() === PHP_SESSION_NONE) {
+    session_start();
+}
+
 // Include necessary files using relative paths (consistent with other pages)
 
 require_once './../../config/config.php';


### PR DESCRIPTION
## Summary
- ensure product API starts a session before using Auth

## Testing
- `php -l src/api/produits/get_produits.php`


------
https://chatgpt.com/codex/tasks/task_e_688bb1f89fb08324af6c51b50b9fd4bb