### PR TITLE
Start session for user management AJAX endpoints

### DIFF
--- a/Bikorwa/src/views/employes/get_user.php
+++ b/Bikorwa/src/views/employes/get_user.php
@@ -13,6 +13,7 @@ require_once './../../../src/config/database.php';
 require_once './../../../src/utils/Auth.php';
 require_once './../../../src/models/User.php';
 require_once './../../../src/controllers/AuthController.php';
+require_once './../../../includes/session.php';
 
 // Initialize database connection
 $database = new Database();

--- a/Bikorwa/src/views/employes/process_users.php
+++ b/Bikorwa/src/views/employes/process_users.php
@@ -13,6 +13,7 @@ require_once './../../../src/config/database.php';
 require_once './../../../src/utils/Auth.php';
 require_once './../../../src/models/User.php';
 require_once './../../../src/controllers/AuthController.php';
+require_once './../../../includes/session.php';
 
 // Initialize database connection
 $database = new Database();


### PR DESCRIPTION
## Summary
- ensure sessions are initialized in user management AJAX handlers to allow access checks

## Testing
- `php -l src/views/employes/process_users.php`
- `php -l src/views/employes/get_user.php`


------
https://chatgpt.com/codex/tasks/task_e_688bb438d04c8324a0ed9cdc075f7004