### PR TITLE
Fix session handling for product search

### DIFF
--- a/Bikorwa/src/api/produits/get_produits.php
+++ b/Bikorwa/src/api/produits/get_produits.php
@@ -1,8 +1,13 @@
 <?php
 // API endpoint to get products with stock information
 
-// Start session if not already started
+// Start or resume session
 if (session_status() === PHP_SESSION_NONE) {
+    if (isset($_GET['PHPSESSID'])) {
+        session_id($_GET['PHPSESSID']);
+    } elseif (isset($_POST['PHPSESSID'])) {
+        session_id($_POST['PHPSESSID']);
+    }
     session_start();
 }
 

--- a/Bikorwa/src/views/stock/ajustement.php
+++ b/Bikorwa/src/views/stock/ajustement.php
@@ -653,7 +653,7 @@ $(document).ready(function() {
                 type: 'GET',
                 // We want to search among all products regardless of their
                 // current stock level, so we don't filter by available stock
-                data: { search: search, with_stock: false },
+                data: { search: search, with_stock: false, PHPSESSID: '<?= session_id() ?>' },
                 dataType: 'json',
                 success: function(response) {
                     if (response.success) {


### PR DESCRIPTION
## Summary
- Ensure product search requests include session ID
- Allow API endpoint to resume sessions from provided PHPSESSID

## Testing
- `php -l Bikorwa/src/api/produits/get_produits.php`
- `php -l Bikorwa/src/views/stock/ajustement.php`


------
https://chatgpt.com/codex/tasks/task_e_688bb6487a708324bf4ad3cb5e1b367e