### PR TITLE
Fix unauthorized access for user management actions

### DIFF
--- a/Bikorwa/src/views/employes/get_user.php
+++ b/Bikorwa/src/views/employes/get_user.php
@@ -13,6 +13,13 @@ require_once './../../../src/config/database.php';
 require_once './../../../src/utils/Auth.php';
 require_once './../../../src/models/User.php';
 require_once './../../../src/controllers/AuthController.php';
+if (session_status() === PHP_SESSION_NONE) {
+    if (isset($_GET['PHPSESSID'])) {
+        session_id($_GET['PHPSESSID']);
+    } elseif (isset($_POST['PHPSESSID'])) {
+        session_id($_POST['PHPSESSID']);
+    }
+}
 require_once './../../../includes/session.php';
 
 // Initialize database connection

--- a/Bikorwa/src/views/employes/process_users.php
+++ b/Bikorwa/src/views/employes/process_users.php
@@ -13,6 +13,9 @@ require_once './../../../src/config/database.php';
 require_once './../../../src/utils/Auth.php';
 require_once './../../../src/models/User.php';
 require_once './../../../src/controllers/AuthController.php';
+if (session_status() === PHP_SESSION_NONE && isset($_POST['PHPSESSID'])) {
+    session_id($_POST['PHPSESSID']);
+}
 require_once './../../../includes/session.php';
 
 // Initialize database connection

--- a/Bikorwa/src/views/employes/utilisateurs.php
+++ b/Bikorwa/src/views/employes/utilisateurs.php
@@ -652,7 +652,10 @@ try {
             </div>
         </div>
     </div>
-    
+
+    <script>
+        const PHPSESSID = '<?php echo session_id(); ?>';
+    </script>
     <script src="./utilisateurs_script.js"></script>
     
     <?php

--- a/Bikorwa/src/views/employes/utilisateurs_script.js
+++ b/Bikorwa/src/views/employes/utilisateurs_script.js
@@ -38,11 +38,13 @@ document.addEventListener('DOMContentLoaded', function() {
         const formData = new FormData(form);
         formData.append('action', 'add');
         formData.append('actif', form.querySelector('#add_actif').checked ? '1' : '0');
-        
+        formData.append('PHPSESSID', PHPSESSID);
+
         // Send AJAX request
         fetch('./process_users.php', {
             method: 'POST',
-            body: formData
+            body: formData,
+            credentials: 'same-origin'
         })
         .then(response => response.json())
         .then(data => {
@@ -98,11 +100,13 @@ document.addEventListener('DOMContentLoaded', function() {
         const formData = new FormData(form);
         formData.append('action', 'update');
         formData.append('actif', form.querySelector('#edit_actif').checked ? '1' : '0');
-        
+        formData.append('PHPSESSID', PHPSESSID);
+
         // Send AJAX request
         fetch('./process_users.php', {
             method: 'POST',
-            body: formData
+            body: formData,
+            credentials: 'same-origin'
         })
         .then(response => response.json())
         .then(data => {
@@ -192,7 +196,7 @@ function viewUser(id) {
     document.body.style.cursor = 'wait';
     
     // Fetch user details
-    fetch(`./get_user.php?id=${id}`)
+    fetch(`./get_user.php?id=${id}&PHPSESSID=${PHPSESSID}`, {credentials: 'same-origin'})
         .then(response => response.json())
         .then(data => {
             // Reset cursor
@@ -249,7 +253,7 @@ function editUser(id) {
     document.body.style.cursor = 'wait';
     
     // Fetch user details
-    fetch(`./get_user.php?id=${id}`)
+    fetch(`./get_user.php?id=${id}&PHPSESSID=${PHPSESSID}`, {credentials: 'same-origin'})
         .then(response => response.json())
         .then(data => {
             // Reset cursor
@@ -319,7 +323,8 @@ function deleteUser(id, nom) {
             headers: {
                 'Content-Type': 'application/x-www-form-urlencoded',
             },
-            body: `action=delete&id=${id}`
+            body: `action=delete&id=${id}&PHPSESSID=${encodeURIComponent(PHPSESSID)}`,
+            credentials: 'same-origin'
         })
         .then(response => response.json())
         .then(data => {
@@ -401,7 +406,8 @@ function toggleStatus(id, isActive) {
             headers: {
                 'Content-Type': 'application/x-www-form-urlencoded',
             },
-            body: `action=toggle_status&id=${id}&actif=${isActive ? '0' : '1'}`
+            body: `action=toggle_status&id=${id}&actif=${isActive ? '0' : '1'}&PHPSESSID=${encodeURIComponent(PHPSESSID)}`,
+            credentials: 'same-origin'
         })
         .then(response => response.json())
         .then(data => {


### PR DESCRIPTION
## Summary
- Pass current session ID to front-end and AJAX requests on user management page
- Ensure `process_users.php` and `get_user.php` restore sessions based on provided PHPSESSID
- Use `same-origin` credentials for all user management fetch calls

## Testing
- `php -l Bikorwa/src/views/employes/utilisateurs.php`
- `php -l Bikorwa/src/views/employes/process_users.php`
- `php -l Bikorwa/src/views/employes/get_user.php`


------
https://chatgpt.com/codex/tasks/task_e_688bbb8552948324b65d27297c514118