### PR TITLE
Enable editing of supply entries in history modal

### DIFF
--- a/Bikorwa/src/views/stock/get_date_supplies.php
+++ b/Bikorwa/src/views/stock/get_date_supplies.php
@@ -41,12 +41,15 @@ try {
     }
 
     // Fetch all supplies for the specified date
-    $sql = "SELECT 
-        m.id, 
-        p.nom AS produit_nom, 
-        m.quantite, 
-        m.prix_unitaire, 
-        m.valeur_totale, 
+    // Include produit_id and full date_mouvement for editing capabilities
+    $sql = "SELECT
+        m.id,
+        m.produit_id,
+        p.nom AS produit_nom,
+        m.quantite,
+        m.prix_unitaire,
+        m.valeur_totale,
+        m.date_mouvement,
         TIME(m.date_mouvement) AS heure,
         u.nom AS utilisateur_nom
     FROM mouvements_stock m
@@ -78,10 +81,12 @@ try {
     foreach ($supplies as $supply) {
         $formatted_supplies[] = [
             'id' => $supply['id'],
+            'produit_id' => $supply['produit_id'],
             'produit_nom' => $supply['produit_nom'],
             'quantite' => $supply['quantite'],
             'prix_unitaire' => floatval($supply['prix_unitaire']),
             'valeur_totale' => floatval($supply['valeur_totale']),
+            'date_mouvement' => $supply['date_mouvement'],
             'heure' => $supply['heure'],
             'utilisateur_nom' => $supply['utilisateur_nom']
         ];

--- a/Bikorwa/src/views/stock/historique_approvisionnement.php
+++ b/Bikorwa/src/views/stock/historique_approvisionnement.php
@@ -408,8 +408,9 @@ try {
                                     <th>Quantité</th>
                                     <th>Prix Unitaire</th>
                                     <th>Valeur Totale</th>
-                                    <th>Heure</th>
+                                    <th>Date</th>
                                     <th>Utilisateur</th>
+                                    <th>Actions</th>
                                 </tr>
                             </thead>
                             <tbody id="modalTableBody">
@@ -541,20 +542,77 @@ document.addEventListener('DOMContentLoaded', function() {
         if (supplies.length > 0) {
             supplies.forEach(supply => {
                 const row = document.createElement('tr');
+                row.dataset.id = supply.id;
+                row.dataset.produitId = supply.produit_id;
+                const dateValue = supply.date_mouvement.replace(' ', 'T').slice(0,16);
                 row.innerHTML = `
                     <td>${escapeHtml(supply.id)}</td>
                     <td>${escapeHtml(supply.produit_nom)}</td>
-                    <td>${escapeHtml(supply.quantite)}</td>
-                    <td>${formatNumber(supply.prix_unitaire)} BIF</td>
-                    <td>${formatNumber(supply.valeur_totale)} BIF</td>
-                    <td>${escapeHtml(supply.heure)}</td>
+                    <td><input type="number" class="form-control form-control-sm quantite-input" value="${escapeHtml(supply.quantite)}"></td>
+                    <td><input type="number" step="0.01" class="form-control form-control-sm prix-input" value="${escapeHtml(supply.prix_unitaire)}"></td>
+                    <td class="valeur-cell">${formatNumber(supply.valeur_totale)} BIF</td>
+                    <td><input type="datetime-local" class="form-control form-control-sm date-input" value="${dateValue}"></td>
                     <td>${escapeHtml(supply.utilisateur_nom)}</td>
+                    <td><button class="btn btn-sm btn-primary save-row"><i class="fas fa-save"></i></button></td>
                 `;
                 tbody.appendChild(row);
             });
+
+            // Update total value when quantity or price changes
+            tbody.querySelectorAll('.quantite-input, .prix-input').forEach(input => {
+                input.addEventListener('input', function() {
+                    const row = this.closest('tr');
+                    const q = parseFloat(row.querySelector('.quantite-input').value) || 0;
+                    const p = parseFloat(row.querySelector('.prix-input').value) || 0;
+                    row.querySelector('.valeur-cell').textContent = formatNumber(q * p) + ' BIF';
+                });
+            });
+
+            // Save button handler for each row
+            tbody.querySelectorAll('.save-row').forEach(button => {
+                button.addEventListener('click', function() {
+                    const row = this.closest('tr');
+                    const id = row.dataset.id;
+                    const produitId = row.dataset.produitId;
+                    const quantite = row.querySelector('.quantite-input').value;
+                    const prix = row.querySelector('.prix-input').value;
+                    const date = row.querySelector('.date-input').value;
+
+                    const formData = new FormData();
+                    formData.append('id', id);
+                    formData.append('produit_id', produitId);
+                    formData.append('quantite', quantite);
+                    formData.append('prix_unitaire', prix);
+                    formData.append('date_mouvement', date.replace('T', ' ') + ':00');
+                    formData.append('PHPSESSID', '<?= session_id() ?>');
+
+                    fetch('<?= BASE_URL ?>/src/views/stock/update_supply.php', {
+                        method: 'POST',
+                        body: formData,
+                        credentials: 'same-origin'
+                    })
+                    .then(response => response.json())
+                    .then(data => {
+                        if (data.success) {
+                            if (typeof toastr !== 'undefined') {
+                                toastr.success(data.message || 'Mise à jour réussie');
+                            }
+                        } else {
+                            if (typeof toastr !== 'undefined') {
+                                toastr.error(data.message || 'Erreur lors de la mise à jour');
+                            }
+                        }
+                    })
+                    .catch(() => {
+                        if (typeof toastr !== 'undefined') {
+                            toastr.error('Erreur de connexion au serveur');
+                        }
+                    });
+                });
+            });
         } else {
             const row = document.createElement('tr');
-            row.innerHTML = '<td colspan="7" class="text-center text-muted">Aucun approvisionnement trouvé pour cette date.</td>';
+            row.innerHTML = '<td colspan="8" class="text-center text-muted">Aucun approvisionnement trouvé pour cette date.</td>';
             tbody.appendChild(row);
         }
         
@@ -582,5 +640,19 @@ document.addEventListener('DOMContentLoaded', function() {
 </script>
 
 <?php require_once __DIR__ . '/../layouts/footer.php'; ?>
-</body>
-</html>
+<?php if (!isset($toastr_included)) { ?>
+<link rel="preconnect" href="https://cdnjs.cloudflare.com" crossorigin>
+<link href="https://cdnjs.cloudflare.com/ajax/libs/toastr.js/latest/css/toastr.min.css" rel="stylesheet" />
+<?php $toastr_included = true; } ?>
+<script src="https://cdnjs.cloudflare.com/ajax/libs/toastr.js/latest/js/toastr.min.js" crossorigin></script>
+<script>
+if (window.toastr) {
+    toastr.options = {
+        closeButton: true,
+        progressBar: true,
+        positionClass: 'toast-top-right',
+        timeOut: 5000,
+        newestOnTop: true
+    };
+}
+</script>

--- a/Bikorwa/src/views/stock/update_supply.php
+++ b/Bikorwa/src/views/stock/update_supply.php
@@ -28,37 +28,62 @@ if (!$id) {
     exit;
 }
 
-// Prepare data
-$produit_id = $_POST['produit_id'];
-$quantite = $_POST['quantite'];
-$prix_unitaire = $_POST['prix_unitaire'];
-$date_mouvement = $_POST['date_mouvement'];
+// Fetch current movement data for comparison
+$stmt = $pdo->prepare("SELECT produit_id, quantite, date_mouvement FROM mouvements_stock WHERE id = ?");
+$stmt->execute([$id]);
+$current = $stmt->fetch(PDO::FETCH_ASSOC);
+
+if (!$current) {
+    echo json_encode(['success' => false, 'message' => 'Approvisionnement introuvable']);
+    exit;
+}
+
+// Prepare new data
+$produit_id = $_POST['produit_id'] ?? $current['produit_id'];
+$quantite = (float)($_POST['quantite'] ?? 0);
+$prix_unitaire = (float)($_POST['prix_unitaire'] ?? 0);
+$date_mouvement = $_POST['date_mouvement'] ?? $current['date_mouvement'];
 $reference = $_POST['reference'] ?? null;
 $note = $_POST['note'] ?? null;
 
-// Update supply entry
-$query = "UPDATE mouvements_stock SET
-    produit_id = ?,
-    quantite = ?,
-    prix_unitaire = ?,
-    date_mouvement = ?,
-    reference = ?,
-    note = ?
-WHERE id = ?";
+try {
+    $pdo->beginTransaction();
 
-$stmt = $pdo->prepare($query);
-$success = $stmt->execute([
-    $produit_id,
-    $quantite,
-    $prix_unitaire,
-    $date_mouvement,
-    $reference,
-    $note,
-    $id
-]);
+    // Update supply entry
+    $query = "UPDATE mouvements_stock SET
+        produit_id = ?,
+        quantite = ?,
+        prix_unitaire = ?,
+        valeur_totale = ?,
+        date_mouvement = ?,
+        reference = ?,
+        note = ?
+    WHERE id = ?";
 
-if ($success) {
-    echo json_encode(['success' => true]);
-} else {
+    $stmt = $pdo->prepare($query);
+    $stmt->execute([
+        $produit_id,
+        $quantite,
+        $prix_unitaire,
+        $quantite * $prix_unitaire,
+        $date_mouvement,
+        $reference,
+        $note,
+        $id
+    ]);
+
+    // Adjust stock if quantity changed
+    $oldQuantite = (float)$current['quantite'];
+    $diff = $quantite - $oldQuantite;
+    if ($diff !== 0.0) {
+        $stockQuery = "UPDATE stock SET quantite = quantite + ? WHERE produit_id = ?";
+        $stockStmt = $pdo->prepare($stockQuery);
+        $stockStmt->execute([$diff, $produit_id]);
+    }
+
+    $pdo->commit();
+    echo json_encode(['success' => true, 'message' => 'Mise à jour réussie']);
+} catch (Exception $e) {
+    $pdo->rollBack();
     echo json_encode(['success' => false, 'message' => 'Erreur de mise à jour']);
 }


### PR DESCRIPTION
## Summary
- Make search modal rows editable and add save actions
- Return produit_id and date_mouvement in date-based supply lookup
- Adjust stock quantities when supply entries are updated
- Display toast notifications after saving supply edits

## Testing
- `php -l Bikorwa/src/views/stock/get_date_supplies.php`
- `php -l Bikorwa/src/views/stock/update_supply.php`
- `php -l Bikorwa/src/views/stock/historique_approvisionnement.php`


------
https://chatgpt.com/codex/tasks/task_e_688bba378f748324af8184bfa6811219