### PR TITLE
Populate view modal date field

### DIFF
--- a/Bikorwa/src/views/ventes/index.php
+++ b/Bikorwa/src/views/ventes/index.php
@@ -942,9 +942,9 @@ $(function() {
                         const vente = response.vente;
                         const produits = response.produits;
                         
-                        // Format date
-                        const date = new Date(vente.date_vente).toLocaleString('fr-FR');
-                        
+                        // Format date for date input (YYYY-MM-DD)
+                        const date = vente.date_vente ? vente.date_vente.split(' ')[0] : '';
+
                         // Update sale info
                         $('#view-numero-facture').text(vente.numero_facture);
                         $('#edit-date').val(date);


### PR DESCRIPTION
## Summary
- Use sale date from database to auto-fill date input when opening view modal.

## Testing
- `php -l Bikorwa/src/views/ventes/index.php`


------
https://chatgpt.com/codex/tasks/task_e_688bc50b2a4083248ad1047689480c9a