### PR TITLE
Compute COGS from sales details

### DIFF
--- a/Bikorwa/src/views/rapports/rapports_ventes.php
+++ b/Bikorwa/src/views/rapports/rapports_ventes.php
@@ -136,12 +136,13 @@ try {
     $gross_profit = 0;
     $net_profit = 0;
     
-    // 1. Coût des Marchandises Vendues - calculé à partir des mouvements de stock (sorties)
+    // 1. Coût des Marchandises Vendues - basé sur les ventes actives dans la période
     $cogs_query = "SELECT
-            SUM(valeur_totale) AS total_cogs
-        FROM mouvements_stock
-        WHERE type_mouvement = 'sortie'
-        AND DATE(date_mouvement) BETWEEN :date_debut AND :date_fin";
+            SUM(dv.prix_achat_unitaire * dv.quantite) AS total_cogs
+        FROM details_ventes dv
+        JOIN ventes v ON dv.vente_id = v.id
+        WHERE DATE(v.date_vente) BETWEEN :date_debut AND :date_fin
+        AND v.statut_vente = 'active'";
     $cogs_stmt = $pdo->prepare($cogs_query);
     $cogs_stmt->execute([':date_debut' => $date_debut, ':date_fin' => $date_fin]);
     $cogs_result = $cogs_stmt->fetch(PDO::FETCH_ASSOC);


### PR DESCRIPTION
## Summary
- derive cost of goods from joined sales and detail records

## Testing
- `php -l Bikorwa/src/views/rapports/rapports_ventes.php`


------
https://chatgpt.com/codex/tasks/task_e_688cba205a748324a4a54adcc163f2ea