### PR TITLE
Fix product selection in sales modal

### DIFF
--- a/Bikorwa/src/views/ventes/index.php
+++ b/Bikorwa/src/views/ventes/index.php
@@ -797,7 +797,7 @@ $(function() {
 
     function loadAvailableProducts(callback) {
         if (availableProducts.length === 0) {
-            $.getJSON('nouvelle.php?action=get_produits&with_stock=true', function(res) {
+            $.getJSON('<?= BASE_URL ?>/src/views/ventes/nouvelle.php?action=get_produits&with_stock=true', function(res) {
                 if (res.success) {
                     availableProducts = res.produits;
                 }
@@ -841,7 +841,7 @@ $(function() {
         placeholder: 'Rechercher un produit',
         allowClear: true,
         ajax: {
-            url: 'nouvelle.php?action=get_produits',
+            url: '<?= BASE_URL ?>/src/views/ventes/nouvelle.php?action=get_produits',
             dataType: 'json',
             delay: 250,
             data: function(params) {


### PR DESCRIPTION
## Summary
- Ensure product dropdown in sales modal loads items by using BASE_URL for AJAX paths

## Testing
- `php -l Bikorwa/src/views/ventes/index.php`


------
https://chatgpt.com/codex/tasks/task_e_6890ab152208832483766a563fab8b1c