### PR TITLE
Remove invoice link from debts and allow manual date

### DIFF
--- a/Bikorwa/src/api/dettes/add_dette.php
+++ b/Bikorwa/src/api/dettes/add_dette.php
@@ -25,6 +25,7 @@ $user_id = $_SESSION['user_id'] ?? 0;
 $client_id = isset($_POST['client_id']) ? intval($_POST['client_id']) : 0;
 $vente_id = !empty($_POST['vente_id']) ? intval($_POST['vente_id']) : null;
 $montant_initial = isset($_POST['montant_initial']) ? floatval($_POST['montant_initial']) : 0;
+$date_creation = !empty($_POST['date_creation']) ? $_POST['date_creation'] : date('Y-m-d');
 $date_echeance = !empty($_POST['date_echeance']) ? $_POST['date_echeance'] : null;
 $note = $_POST['note'] ?? '';
 
@@ -39,16 +40,17 @@ try {
     $conn->beginTransaction();
     
     // Insert new debt
-    $query = "INSERT INTO dettes (client_id, vente_id, montant_initial, montant_restant, date_echeance, note)
-              VALUES (?, ?, ?, ?, ?, ?)";
-    
+    $query = "INSERT INTO dettes (client_id, vente_id, montant_initial, montant_restant, date_creation, date_echeance, note)
+              VALUES (?, ?, ?, ?, ?, ?, ?)";
+
     $stmt = $conn->prepare($query);
     $stmt->bindParam(1, $client_id, PDO::PARAM_INT);
     $stmt->bindParam(2, $vente_id, $vente_id ? PDO::PARAM_INT : PDO::PARAM_NULL);
     $stmt->bindParam(3, $montant_initial, PDO::PARAM_STR);
     $stmt->bindParam(4, $montant_initial, PDO::PARAM_STR); // montant_restant = montant_initial for new debt
-    $stmt->bindParam(5, $date_echeance, $date_echeance ? PDO::PARAM_STR : PDO::PARAM_NULL);
-    $stmt->bindParam(6, $note, PDO::PARAM_STR);
+    $stmt->bindParam(5, $date_creation, PDO::PARAM_STR);
+    $stmt->bindParam(6, $date_echeance, $date_echeance ? PDO::PARAM_STR : PDO::PARAM_NULL);
+    $stmt->bindParam(7, $note, PDO::PARAM_STR);
     
     $stmt->execute();
     $dette_id = $conn->lastInsertId();

--- a/Bikorwa/src/api/dettes/update_dette.php
+++ b/Bikorwa/src/api/dettes/update_dette.php
@@ -31,8 +31,8 @@ $user_id = $_SESSION['user_id'] ?? 0;
 // Get POST data
 $dette_id = isset($_POST['id']) ? intval($_POST['id']) : 0;
 $client_id = isset($_POST['client_id']) ? intval($_POST['client_id']) : 0;
-$vente_id = !empty($_POST['vente_id']) ? intval($_POST['vente_id']) : null;
 $montant_initial = isset($_POST['montant_initial']) ? floatval($_POST['montant_initial']) : 0;
+$date_creation = !empty($_POST['date_creation']) ? $_POST['date_creation'] : null;
 $date_echeance = !empty($_POST['date_echeance']) ? $_POST['date_echeance'] : null;
 $note = $_POST['note'] ?? '';
 
@@ -62,20 +62,20 @@ try {
     $new_montant_restant = round($current_dette['montant_restant'] * $proportion, 2);
     
     // Update debt
-    $query = "UPDATE dettes 
-              SET client_id = ?, 
-                  vente_id = ?, 
-                  montant_initial = ?, 
+    $query = "UPDATE dettes
+              SET client_id = ?,
+                  montant_initial = ?,
                   montant_restant = ?,
-                  date_echeance = ?, 
+                  date_creation = ?,
+                  date_echeance = ?,
                   note = ?
               WHERE id = ?";
-    
+
     $stmt = $conn->prepare($query);
     $stmt->bindParam(1, $client_id, PDO::PARAM_INT);
-    $stmt->bindParam(2, $vente_id, $vente_id ? PDO::PARAM_INT : PDO::PARAM_NULL);
-    $stmt->bindParam(3, $montant_initial, PDO::PARAM_STR);
-    $stmt->bindParam(4, $new_montant_restant, PDO::PARAM_STR);
+    $stmt->bindParam(2, $montant_initial, PDO::PARAM_STR);
+    $stmt->bindParam(3, $new_montant_restant, PDO::PARAM_STR);
+    $stmt->bindParam(4, $date_creation, $date_creation ? PDO::PARAM_STR : PDO::PARAM_NULL);
     $stmt->bindParam(5, $date_echeance, $date_echeance ? PDO::PARAM_STR : PDO::PARAM_NULL);
     $stmt->bindParam(6, $note, PDO::PARAM_STR);
     $stmt->bindParam(7, $dette_id, PDO::PARAM_INT);

--- a/Bikorwa/src/views/dettes/fixed_script.js
+++ b/Bikorwa/src/views/dettes/fixed_script.js
@@ -97,18 +97,6 @@ document.addEventListener('DOMContentLoaded', function() {
         savePaiement();
     });
     
-    // Client selection change - load related invoices
-    document.getElementById('client_id_form').addEventListener('change', function() {
-        const clientId = this.value;
-        if (clientId) {
-            loadClientInvoices(clientId);
-        } else {
-            // Clear invoices dropdown
-            const invoiceSelect = document.getElementById('vente_id');
-            invoiceSelect.innerHTML = '<option value="">Aucune facture associée</option>';
-        }
-    });
-    
     // Functions
     
     // Load debt details for view modal
@@ -230,10 +218,13 @@ document.addEventListener('DOMContentLoaded', function() {
                     } else {
                         document.getElementById('date_echeance').value = '';
                     }
-                    
-                    // Load invoices for this client
-                    loadClientInvoices(dette.client_id, dette.vente_id);
-                    
+
+                    if (dette.date_creation) {
+                        document.getElementById('date_creation').value = dette.date_creation.split(' ')[0];
+                    } else {
+                        document.getElementById('date_creation').value = '';
+                    }
+
                     // Show modal
                     detteModal.show();
                     
@@ -543,51 +534,6 @@ document.addEventListener('DOMContentLoaded', function() {
             showToast('Erreur', 'Une erreur est survenue lors de l\'annulation', 'error');
             deleteModal.hide();
         });
-    }
-    
-    // Load client invoices
-    function loadClientInvoices(clientId, selectedInvoiceId = null) {
-        if (!clientId) {
-            const invoiceSelect = document.getElementById('vente_id');
-            invoiceSelect.innerHTML = '<option value="">Aucune facture associée</option>';
-            return;
-        }
-        
-        // Show loading state
-        const invoiceSelect = document.getElementById('vente_id');
-        invoiceSelect.innerHTML = '<option value="">Chargement des factures...</option>';
-        invoiceSelect.disabled = true;
-        
-        fetch(`${baseUrl}/src/api/dettes/get_client_invoices.php?client_id=${clientId}`)
-            .then(response => {
-                if (!response.ok) {
-                    throw new Error(`HTTP error! Status: ${response.status}`);
-                }
-                return response.json();
-            })
-            .then(data => {
-                // Re-enable and reset select
-                invoiceSelect.disabled = false;
-                invoiceSelect.innerHTML = '<option value="">Aucune facture associée</option>';
-                
-                if (data.success && data.invoices && data.invoices.length > 0) {
-                    data.invoices.forEach(invoice => {
-                        const option = document.createElement('option');
-                        option.value = invoice.id;
-                        option.textContent = `${invoice.numero_facture} (${formatMontant(invoice.montant_total)} F)`;
-                        if (selectedInvoiceId && invoice.id == selectedInvoiceId) {
-                            option.selected = true;
-                        }
-                        invoiceSelect.appendChild(option);
-                    });
-                }
-            })
-            .catch(error => {
-                console.error('Error:', error);
-                invoiceSelect.disabled = false;
-                invoiceSelect.innerHTML = '<option value="">Aucune facture associée</option>';
-                showToast('Erreur', 'Impossible de charger les factures du client', 'error');
-            });
     }
     
     // Format amount with thousands separator

--- a/Bikorwa/src/views/dettes/index.php
+++ b/Bikorwa/src/views/dettes/index.php
@@ -658,21 +658,18 @@ require_once __DIR__ . '/../layouts/header.php';
                                 </div>
                                 
                                 <div class="mb-3">
-                                    <label for="vente_id" class="form-label">Facture associée</label>
-                                    <select class="form-select" id="vente_id" name="vente_id">
-                                        <option value="">Aucune facture associée</option>
-                                        <!-- Rempli dynamiquement lors de la sélection du client -->
-                                    </select>
-                                </div>
-                                
-                                <div class="mb-3">
                                     <label for="montant_initial" class="form-label">Montant initial <span class="text-danger">*</span></label>
                                     <div class="input-group">
                                         <input type="number" class="form-control" id="montant_initial" name="montant_initial" required min="1" step="1">
                                         <span class="input-group-text">F</span>
                                     </div>
                                 </div>
-                                
+
+                                <div class="mb-3">
+                                    <label for="date_creation" class="form-label">Date de la dette <span class="text-danger">*</span></label>
+                                    <input type="date" class="form-control" id="date_creation" name="date_creation" required value="<?php echo date('Y-m-d'); ?>">
+                                </div>
+
                                 <div class="mb-3">
                                     <label for="date_echeance" class="form-label">Date d'échéance</label>
                                     <input type="date" class="form-control" id="date_echeance" name="date_echeance">


### PR DESCRIPTION
## Summary
- remove invoice association dropdown from manual debt entry and require date selection
- populate manual date in edit modal and drop invoice loading logic
- accept `date_creation` in add/update debt APIs

## Testing
- `php -l Bikorwa/src/views/dettes/index.php`
- `php -l Bikorwa/src/api/dettes/add_dette.php`
- `php -l Bikorwa/src/api/dettes/update_dette.php`
- `node --check Bikorwa/src/views/dettes/fixed_script.js`


------
https://chatgpt.com/codex/tasks/task_e_6890ad7ccf488324891b83f53b4b1e6d