### PR TITLE
fix: handle null optional fields in debt APIs

### DIFF
--- a/Bikorwa/src/api/dettes/add_dette.php
+++ b/Bikorwa/src/api/dettes/add_dette.php
@@ -45,11 +45,27 @@ try {
 
     $stmt = $conn->prepare($query);
     $stmt->bindParam(1, $client_id, PDO::PARAM_INT);
-    $stmt->bindParam(2, $vente_id, $vente_id ? PDO::PARAM_INT : PDO::PARAM_NULL);
+
+    // Vente ID may be null. bindValue handles null values correctly while
+    // bindParam with PARAM_NULL can lead to unexpected behaviour on some
+    // drivers.  Use bindValue when the value is null.
+    if ($vente_id !== null) {
+        $stmt->bindParam(2, $vente_id, PDO::PARAM_INT);
+    } else {
+        $stmt->bindValue(2, null, PDO::PARAM_NULL);
+    }
+
     $stmt->bindParam(3, $montant_initial, PDO::PARAM_STR);
     $stmt->bindParam(4, $montant_initial, PDO::PARAM_STR); // montant_restant = montant_initial for new debt
     $stmt->bindParam(5, $date_creation, PDO::PARAM_STR);
-    $stmt->bindParam(6, $date_echeance, $date_echeance ? PDO::PARAM_STR : PDO::PARAM_NULL);
+
+    // date_echeance is optional and may be null as well
+    if ($date_echeance !== null) {
+        $stmt->bindParam(6, $date_echeance, PDO::PARAM_STR);
+    } else {
+        $stmt->bindValue(6, null, PDO::PARAM_NULL);
+    }
+
     $stmt->bindParam(7, $note, PDO::PARAM_STR);
     
     $stmt->execute();

--- a/Bikorwa/src/api/dettes/update_dette.php
+++ b/Bikorwa/src/api/dettes/update_dette.php
@@ -75,8 +75,21 @@ try {
     $stmt->bindParam(1, $client_id, PDO::PARAM_INT);
     $stmt->bindParam(2, $montant_initial, PDO::PARAM_STR);
     $stmt->bindParam(3, $new_montant_restant, PDO::PARAM_STR);
-    $stmt->bindParam(4, $date_creation, $date_creation ? PDO::PARAM_STR : PDO::PARAM_NULL);
-    $stmt->bindParam(5, $date_echeance, $date_echeance ? PDO::PARAM_STR : PDO::PARAM_NULL);
+
+    // date_creation and date_echeance are optional. Use bindValue when the
+    // value is null to ensure PDO correctly sends NULL to the database.
+    if ($date_creation !== null) {
+        $stmt->bindParam(4, $date_creation, PDO::PARAM_STR);
+    } else {
+        $stmt->bindValue(4, null, PDO::PARAM_NULL);
+    }
+
+    if ($date_echeance !== null) {
+        $stmt->bindParam(5, $date_echeance, PDO::PARAM_STR);
+    } else {
+        $stmt->bindValue(5, null, PDO::PARAM_NULL);
+    }
+
     $stmt->bindParam(6, $note, PDO::PARAM_STR);
     $stmt->bindParam(7, $dette_id, PDO::PARAM_INT);
     


### PR DESCRIPTION
## Summary
- ensure add_dette handles nullable vente_id and date_echeance correctly
- ensure update_dette handles nullable date fields safely

## Testing
- `php -l Bikorwa/src/api/dettes/add_dette.php`
- `php -l Bikorwa/src/api/dettes/update_dette.php`


------
https://chatgpt.com/codex/tasks/task_e_6890b40d2b548324be3a710b4dca25d5