### PR TITLE
Allow authorized users to edit debts

### DIFF
--- a/Bikorwa/src/api/dettes/update_dette.php
+++ b/Bikorwa/src/api/dettes/update_dette.php
@@ -46,14 +46,16 @@ try {
         exit;
     }
 
-    // Only managers can update debts
+    // Check access permissions: allow users with dettes access or managers
     $user_role = strtolower($_SESSION['role'] ?? '');
-    if ($user_role !== 'gestionnaire') {
+    $has_dettes_access = $auth->hasAccess('dettes');
+
+    if (!$has_dettes_access && $user_role !== 'gestionnaire') {
         http_response_code(403);
-        $response['message'] = "Permission refusée: seuls les gestionnaires peuvent modifier des dettes";
+        $response['message'] = "Permission refusée: vous n'avez pas l'autorisation de modifier des dettes";
         $response['debug'] = [
             'session_role' => $user_role,
-            'expected_role' => 'gestionnaire',
+            'has_access' => $has_dettes_access,
             'session_data' => $_SESSION ?? null,
             'user_id' => $_SESSION['user_id'] ?? 'NOT_SET'
         ];


### PR DESCRIPTION
## Summary
- permit non-manager roles with debt access to update debt records

## Testing
- `php -l Bikorwa/src/api/dettes/update_dette.php`


------
https://chatgpt.com/codex/tasks/task_e_6890dc44bad48324963ea76dc5dbfe9c